### PR TITLE
Fix search with filters

### DIFF
--- a/app/components/search/form_component.html.erb
+++ b/app/components/search/form_component.html.erb
@@ -1,4 +1,7 @@
 <%= helpers.form_with model: search_form, scope: :search, url:, method: :get do |form| %>
+  <% search_form.this_attributes.each do |attr_name, value| %>
+    <%= form.hidden_field attr_name.to_sym, value: value, multiple: true %>
+  <% end %>
   <%= form.label :query, label %>
   <%= form.text_field :query %>
   <%= form.submit 'Search' %>

--- a/app/forms/search/form.rb
+++ b/app/forms/search/form.rb
@@ -57,5 +57,11 @@ module Search
       # This drops attributes with false values so that they are not included in URLs.
       super.compact_blank
     end
+
+    # @return [Hash] attributes defined on this class (not its superclasses)
+    def this_attributes
+      # To be overridden in subclasses
+      []
+    end
   end
 end

--- a/app/forms/search/item_form.rb
+++ b/app/forms/search/item_form.rb
@@ -6,6 +6,13 @@ module Search
     attribute :object_types, array: true, default: -> { [] }
     attribute :projects, array: true, default: -> { [] }
 
+    # @return [Hash] attributes defined on this class (not its superclasses)
+    def this_attributes
+      attributes.slice(*self.class.this_attribute_names)
+    end
+
+    delegate :this_attribute_names, to: :class
+
     # @return [Array<Array(String, String)>] current filters as attribute name/value pairs
     def current_filters
       self.class.this_attribute_names.flat_map do |attr_name|

--- a/app/views/search/items/index.html.erb
+++ b/app/views/search/items/index.html.erb
@@ -1,6 +1,6 @@
 <h1>Items search page</h1>
 
-<%= render Search::FormComponent.new(search_form: @search_form, url: home_path, label: 'Search for items:') %>
+<%= render Search::FormComponent.new(search_form: @search_form, url: search_items_path, label: 'Search for items:') %>
 
 <%= render Search::CurrentFiltersComponent.new(search_form: @search_form) %>
 

--- a/spec/components/search/form_component_spec.rb
+++ b/spec/components/search/form_component_spec.rb
@@ -4,12 +4,13 @@ require 'rails_helper'
 
 RSpec.describe Search::FormComponent, type: :component do
   let(:component) { described_class.new(search_form:, url: '/search', label: 'Search') }
-  let(:search_form) { Search::Form.new(query: 'test') }
+  let(:search_form) { Search::ItemForm.new(query: 'test', projects: ['Google Books']) }
 
   it 'renders the search form' do
     render_inline(component)
 
     expect(page).to have_css("form[action='/search']")
+    expect(page).to have_field('search[projects][]', type: :hidden, with: 'Google Books')
     expect(page).to have_field('Search', type: :text, with: 'test')
     expect(page).to have_field('Include Google Books', type: :checkbox, checked: false)
     expect(page).to have_button('Search')

--- a/spec/forms/search/form_spec.rb
+++ b/spec/forms/search/form_spec.rb
@@ -89,4 +89,12 @@ RSpec.describe Search::Form do
       end
     end
   end
+
+  describe '#this_attributes' do
+    let(:attributes) { { query: '', page: 2, include_google_books: true } }
+
+    it 'returns empty array' do
+      expect(form.this_attributes).to eq([])
+    end
+  end
 end


### PR DESCRIPTION
This fixes a bug whereby changing the query (in the search form) and executing a new search was ignoring the existing selected facet values.