### PR TITLE
Eagerly fetch expanded hierarchical facets.

### DIFF
--- a/app/components/search/hierarchical_value_component.html.erb
+++ b/app/components/search/hierarchical_value_component.html.erb
@@ -10,7 +10,7 @@
 
   <% if facet_count.branch? %>
     <%= tag.div id: children_collapse_id, class: collapse_classes do %>
-      <%= helpers.turbo_frame_tag children_turbo_id, src: children_path, loading: 'lazy' do %>
+      <%= helpers.turbo_frame_tag children_turbo_id, src: children_path, loading: expanded? ? 'eager' : 'lazy' do %>
         Loading...
       <% end %>
     <% end %>

--- a/spec/components/search/hierarchical_value_component_spec.rb
+++ b/spec/components/search/hierarchical_value_component_spec.rb
@@ -70,7 +70,7 @@ RSpec.describe Search::HierarchicalValueComponent, type: :component do
         expect(page).to have_link('Remove', href: '/search/items')
         expect(page).to have_link('+', href: '#collapse-ocrwf-end-ocr', title: 'Toggle end-ocr')
         expect(page).to have_css('div.collapse.show turbo-frame[src="/search/workflow_facets/children' \
-                                 '?parent_value=ocrWF%3Aend-ocr&wps_workflows%5B%5D=ocrWF%3Aend-ocr"]')
+                                 '?parent_value=ocrWF%3Aend-ocr&wps_workflows%5B%5D=ocrWF%3Aend-ocr"][loading="eager"]')
       end
     end
 
@@ -82,7 +82,7 @@ RSpec.describe Search::HierarchicalValueComponent, type: :component do
         expect(page).to have_content('(10)')
         expect(page).to have_link('+', href: '#collapse-ocrwf-end-ocr')
         expect(page).to have_css('div.collapse:not(.show) turbo-frame[src="/search/workflow_facets/children' \
-                                 '?parent_value=ocrWF%3Aend-ocr"]')
+                                 '?parent_value=ocrWF%3Aend-ocr"][loading="lazy"]')
       end
     end
 
@@ -100,7 +100,8 @@ RSpec.describe Search::HierarchicalValueComponent, type: :component do
         expect(page).to have_content('(10)')
         expect(page).to have_link('+', href: '#collapse-ocrwf-end-ocr')
         expect(page).to have_css('div.collapse.show turbo-frame[src="/search/workflow_facets/children' \
-                                 '?parent_value=ocrWF%3Aend-ocr&wps_workflows%5B%5D=ocrWF%3Aend-ocr%3Awaiting"]')
+                                 '?parent_value=ocrWF%3Aend-ocr&wps_workflows%5B%5D=ocrWF%3Aend-ocr%3Awaiting"]' \
+                                 '[loading="eager"]')
       end
     end
   end


### PR DESCRIPTION
Previously it was waiting until the section came into viewport before fetching which made the load noticeable to user.