### PR TITLE
Improve rendering of current filters.

### DIFF
--- a/app/assets/stylesheets/search.scss
+++ b/app/assets/stylesheets/search.scss
@@ -23,3 +23,10 @@ a[aria-expanded="false"] {
   }
 }
 
+// # Derived from BL .applied-filter .filter-name::after
+.selected-item-separator {
+  color: #adb5bd;
+  font-size: 90%;
+  padding-left: 0.3em;
+}
+

--- a/app/components/elements/selected_item_component.html.erb
+++ b/app/components/elements/selected_item_component.html.erb
@@ -1,6 +1,6 @@
-<li class="d-inline-flex gap-2 align-items-center my-2">
+<li class="d-inline-flex gap-5 align-items-center my-2 me-2">
   <span class="bg-light badge rounded-pill border selected-item">
-    <span class="selected-item-label"><%= label %></span>
+    <span class="selected-item-label"><%= label_content || label %></span>
     <%= render Elements::ButtonLinkComponent.new(label: '', path:, title: "Remove #{label}", classes: 'btn-close') %>
   </span>
 </li>

--- a/app/components/elements/selected_item_component.rb
+++ b/app/components/elements/selected_item_component.rb
@@ -4,8 +4,10 @@ module Elements
   # Component for a selected item badge with a remove link.
   # Implements https://sul-dlss.github.io/component-library/selected_item/
   class SelectedItemComponent < ViewComponent::Base
-    def initialize(label:, path:)
-      @label = label
+    renders_one :label_content
+
+    def initialize(path:, label: nil)
+      @label = label # Provide label or label_content
       @path = path
       super()
     end

--- a/app/components/search/current_filter_component.html.erb
+++ b/app/components/search/current_filter_component.html.erb
@@ -1,0 +1,13 @@
+<%= render Elements::SelectedItemComponent.new(path: remove_path, label:) do |component| %>
+  <%= component.with_label_content do %>
+    <% if query? %>
+      <%= value_label %>
+    <% elsif include_google_books? %>
+      <%= field_label %>
+    <% else %>
+      <%= field_label %>
+      <span class="selected-item-separator">❯</span>
+      <%= value_label %>
+    <% end %>
+  <% end %>
+<% end %>

--- a/app/components/search/current_filter_component.rb
+++ b/app/components/search/current_filter_component.rb
@@ -12,19 +12,26 @@ module Search
 
     attr_reader :form_field, :value, :search_form
 
-    def call
-      render Elements::SelectedItemComponent.new(label:, path: remove_path)
-    end
-
-    private
-
     def label
+      return value_label if query?
+      return field_label if include_google_books?
+
       "#{field_label} > #{value_label}"
     end
 
     def remove_path
       search_items_path(search_form.without_attributes({ form_field => value, page: nil }))
     end
+
+    def query?
+      form_field == 'query'
+    end
+
+    def include_google_books?
+      form_field == 'include_google_books'
+    end
+
+    private
 
     def field_label
       helpers.facet_label(form_field)

--- a/app/components/search/current_filters_component.html.erb
+++ b/app/components/search/current_filters_component.html.erb
@@ -1,7 +1,8 @@
 <section
   aria-label="Current Filters"
-  class="container d-flex align-items-center">
+  class="container d-flex align-items-center mb-3">
   <%= render Elements::DivHeadingComponent.new(level: 2, label: 'Your selections:', class: 'fw-bold me-2') %>
+
   <ul class="list-unstyled d-flex mb-0">
     <% current_filters.each do |form_field, value| %>
       <%= render Search::CurrentFilterComponent.new(form_field:, value:, search_form: @search_form) %>

--- a/app/forms/search/form.rb
+++ b/app/forms/search/form.rb
@@ -66,5 +66,14 @@ module Search
       # To be overridden in subclasses
       {}
     end
+
+    # @return [Array<Array(String, String)>] current filters as attribute name/value pairs
+    def current_filters
+      # To be overridden in subclasses
+      [].tap do |filters|
+        filters << ['query', query] if query.present?
+        filters << ['include_google_books', true] if include_google_books
+      end
+    end
   end
 end

--- a/app/forms/search/item_form.rb
+++ b/app/forms/search/item_form.rb
@@ -22,11 +22,14 @@ module Search
 
     # @return [Array<Array(String, String)>] current filters as attribute name/value pairs
     def current_filters
-      self.class.this_attribute_names.flat_map do |attr_name|
-        values = public_send(attr_name)
-        Array(values).map do |value|
-          [attr_name, value]
+      @current_filters ||= begin
+        filters = self.class.this_attribute_names.flat_map do |attr_name|
+          values = public_send(attr_name)
+          Array(values).map do |value|
+            [attr_name, value]
+          end
         end
+        super + filters
       end
     end
 

--- a/app/views/home/show.html.erb
+++ b/app/views/home/show.html.erb
@@ -2,6 +2,8 @@
 
 <%= render Search::FormComponent.new(search_form: @search_form, url: home_path, label: 'Search for items, tags or projects:') %>
 
+<%= render Search::CurrentFiltersComponent.new(search_form: @search_form) %>
+
 <%= render Search::LayoutComponent.new do |layout| %>
   <%= layout.with_main_content do %>
     <% if @projects_search_form %>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -34,6 +34,7 @@ en:
       wps_workflows: "Workflow > Process > Status"
       mimetypes: "MIME Types"
       released_to_earthworks: "Released to Earthworks"
+      include_google_books: "Include Google Books"
     facet_values:
       ever: "Currently released"
       never: "Not released"

--- a/spec/components/elements/selected_item_component_spec.rb
+++ b/spec/components/elements/selected_item_component_spec.rb
@@ -3,14 +3,35 @@
 require 'rails_helper'
 
 RSpec.describe Elements::SelectedItemComponent, type: :component do
-  let(:component) do
-    described_class.new(label: 'Test Label', path: '/remove/path')
+  context 'with a provided label' do
+    let(:component) do
+      described_class.new(label: 'Test Label', path: '/remove/path')
+    end
+
+    it 'renders the selected item with label and remove link' do
+      render_inline(component)
+
+      expect(page).to have_css('li .selected-item-label', text: 'Test Label')
+      expect(page).to have_link('', href: '/remove/path', title: 'Remove Test Label', class: 'btn-close')
+    end
   end
 
-  it 'renders the selected item with label and remove link' do
-    render_inline(component)
+  context 'with label_content provided' do
+    let(:component) do
+      described_class.new(path: '/remove/path', label: 'Test Label') do |c|
+        c.label_content do
+          'Custom Label Content'
+        end
+      end
+    end
 
-    expect(page).to have_css('li .selected-item-label', text: 'Test Label')
-    expect(page).to have_link('', href: '/remove/path', title: 'Remove Test Label', class: 'btn-close')
+    it 'renders the selected item with label_content and remove link' do
+      render_inline(component) do |component|
+        component.with_label_content { 'Custom Label Content' }
+      end
+
+      expect(page).to have_css('li .selected-item-label', text: 'Custom Label Content')
+      expect(page).to have_link('', href: '/remove/path', title: 'Remove Test Label', class: 'btn-close')
+    end
   end
 end

--- a/spec/components/search/current_filter_component_spec.rb
+++ b/spec/components/search/current_filter_component_spec.rb
@@ -18,7 +18,7 @@ RSpec.describe Search::CurrentFilterComponent, type: :component do
     it 'renders the current filter' do
       render_inline(component)
 
-      expect(page).to have_css('li', text: 'Object types > item')
+      expect(page).to have_css('li', text: /Object types\s+❯\s+item/)
       expect(page).to have_link('',
                                 href: '/search/items?object_types%5B%5D=collection&projects%5B%5D=Project+1',
                                 title: 'Remove Object types > item')
@@ -37,7 +37,7 @@ RSpec.describe Search::CurrentFilterComponent, type: :component do
     it 'renders the current filter' do
       render_inline(component)
 
-      expect(page).to have_css('li', text: 'Released to Earthworks > Last year')
+      expect(page).to have_css('li', text: /Released to Earthworks\s+❯\s+Last year/)
     end
   end
 end

--- a/spec/components/search/current_filters_component_spec.rb
+++ b/spec/components/search/current_filters_component_spec.rb
@@ -8,6 +8,8 @@ RSpec.describe Search::CurrentFiltersComponent, type: :component do
   context 'when there are current filters' do
     let(:search_form) do
       Search::ItemForm.new(
+        query: 'test',
+        include_google_books: true,
         object_types: %w[item collection],
         projects: ['Project 1']
       )
@@ -17,9 +19,11 @@ RSpec.describe Search::CurrentFiltersComponent, type: :component do
       render_inline(component)
 
       expect(page).to have_css('section[aria-label="Current Filters"]')
-      expect(page).to have_css('li', text: 'Object types > item')
-      expect(page).to have_css('li', text: 'Object types > collection')
-      expect(page).to have_css('li', text: 'Projects > Project 1')
+      expect(page).to have_css('li', text: 'test')
+      expect(page).to have_css('li', text: 'Include Google Books')
+      expect(page).to have_css('li', text: /Object types\s+❯\s+item/)
+      expect(page).to have_css('li', text: /Object types\s+❯\s+collection/)
+      expect(page).to have_css('li', text: /Projects\s+❯\s+Project 1/)
       expect(page).to have_link('Clear all', href: '/')
     end
   end

--- a/spec/forms/search/form_spec.rb
+++ b/spec/forms/search/form_spec.rb
@@ -127,4 +127,22 @@ RSpec.describe Search::Form do
       expect(form.this_attributes).to eq({})
     end
   end
+
+  describe '#current_filters' do
+    let(:attributes) { { query: 'test', include_google_books: true } }
+
+    context 'when attributes are set' do
+      it 'returns current filters as attribute name/value pairs' do
+        expect(form.current_filters).to eq([%w[query test], ['include_google_books', true]])
+      end
+    end
+
+    context 'when no attributes are set' do
+      let(:attributes) { {} }
+
+      it 'returns empty array' do
+        expect(form.current_filters).to eq([])
+      end
+    end
+  end
 end

--- a/spec/forms/search/item_form_spec.rb
+++ b/spec/forms/search/item_form_spec.rb
@@ -18,10 +18,12 @@ RSpec.describe Search::ItemForm do
     it 'returns the current filters as attribute name/value pairs' do
       form = described_class.new(
         object_types: %w[item collection],
-        projects: ['Project 1']
+        projects: ['Project 1'],
+        query: 'test'
       )
 
       expect(form.current_filters).to contain_exactly(
+        %w[query test],
         %w[object_types item],
         %w[object_types collection],
         ['projects', 'Project 1']

--- a/spec/support/search_finders.rb
+++ b/spec/support/search_finders.rb
@@ -37,7 +37,12 @@ def find_current_filters_section
 end
 
 def find_current_filter(label, value)
-  find_current_filters_section.find('li', text: "#{label} > #{value}")
+  expected_text = if value
+                    /#{label}\s+❯\s+#{value}/
+                  else
+                    label
+                  end
+  find_current_filters_section.find('li', text: expected_text)
 end
 
 def find_facet_toggle(facet_value, facet_label:)

--- a/spec/support/search_matchers.rb
+++ b/spec/support/search_matchers.rb
@@ -72,8 +72,13 @@ end
 
 RSpec::Matchers.define :have_current_filter do |expected_form_field_name, expected_value, args = {}|
   match do |actual|
+    expected_text = if expected_value
+                      /#{expected_form_field_name}\s+❯\s+#{expected_value}/
+                    else
+                      expected_form_field_name
+                    end
     actual.has_css?('section[aria-label="Current Filters"] li',
-                    text: "#{expected_form_field_name} > #{expected_value}",
+                    text: expected_text,
                     **args)
   end
 end

--- a/spec/system/search/current_filters_spec.rb
+++ b/spec/system/search/current_filters_spec.rb
@@ -17,6 +17,13 @@ RSpec.describe 'Current filters', :solr do
 
     expect(page).to have_result_count(3)
 
+    # Perform a search.
+    fill_in('Search for items', with: 'test')
+    click_button 'Search'
+
+    expect(page).to have_result_count(3)
+    expect(page).to have_current_filter('test')
+
     # Select a facet.
     find_facet_section('Object types').click
     within(find_facet_section('Object types')) do
@@ -27,6 +34,7 @@ RSpec.describe 'Current filters', :solr do
 
     expect(page).to have_result_count(2)
     expect(page).to have_item_result(item_doc)
+    expect(page).to have_current_filter('test')
     expect(page).to have_current_filter('Object types', 'item')
     expect(page).to have_current_filter('Object types', 'agreement')
 
@@ -35,6 +43,7 @@ RSpec.describe 'Current filters', :solr do
     end
 
     expect(page).to have_result_count(1)
+    expect(page).to have_current_filter('test')
     expect(page).not_to have_current_filter('Object types', 'item', wait: 0)
   end
 end


### PR DESCRIPTION
<img width="1474" height="267" alt="image" src="https://github.com/user-attachments/assets/991f2977-b8a9-4d73-96ba-105bd4e812e1" />

* Uses same separator as BL.
* Includes query and "include google books" as current filters.