### PR TITLE
Separate include google books from search field.

### DIFF
--- a/app/components/search/facet_search_component.html.erb
+++ b/app/components/search/facet_search_component.html.erb
@@ -10,7 +10,7 @@
 
   <%= helpers.form_with model: search_form, scope: :search, url: search_path, method: :get do |form| %>
     <%= render Search::FormHiddenFieldsComponent.new(form_builder: form, search_form:) %>
-    <%= form.hidden_field form_field, multiple: true, data: { autocomplete_target: 'hidden', action: 'change->facet-search#submit' } %>
+    <%= form.hidden_field form_field, multiple: true, data: { autocomplete_target: 'hidden', action: 'change->form-submit#submit' } %>
   <% end %>
 
   <ul class="list-group facet-values" data-autocomplete-target="results"></ul>

--- a/app/components/search/facet_search_component.rb
+++ b/app/components/search/facet_search_component.rb
@@ -22,7 +22,7 @@ module Search
     end
 
     def data
-      { controller: 'autocomplete facet-search', autocomplete_url_value: path }
+      { controller: 'autocomplete form-submit', autocomplete_url_value: path }
     end
 
     def classes

--- a/app/components/search/form_component.html.erb
+++ b/app/components/search/form_component.html.erb
@@ -1,7 +1,7 @@
 <div class="bg-light mt-2">
   <nav aria-label="Search form" class="container py-2 mb-3">
     <%= helpers.form_with model: search_form, scope: :search, url:, method: :get do |form| %>
-      <%= render Search::FormHiddenFieldsComponent.new(form_builder: form, search_form:, include_base_fields: false) %>
+      <%= render Search::FormHiddenFieldsComponent.new(form_builder: form, search_form:, form_field: :query) %>
 
       <div class="d-flex align-items-center">
         <%= form.label :query, label, class: 'form-label fw-bold w-auto me-2 mb-0' %>
@@ -18,9 +18,13 @@
           </span>
         </div>
       </div>
+    <% end %>
+
+    <%= helpers.form_with model: search_form, scope: :search, url:, method: :get, data: { controller: 'form-submit' } do |form| %>
+      <%= render Search::FormHiddenFieldsComponent.new(form_builder: form, search_form:, form_field: :include_google_books) %>
 
       <div class="form-check">
-        <%= form.checkbox :include_google_books, include_hidden: false, class: 'form-check-input' %>
+        <%= form.checkbox :include_google_books, include_hidden: false, class: 'form-check-input', data: { action: 'change->form-submit#submit' } %>
         <%= form.label :include_google_books, 'Include Google Books', class: 'form-check-label' %>
       </div>
     <% end %>

--- a/app/components/search/form_hidden_fields_component.rb
+++ b/app/components/search/form_hidden_fields_component.rb
@@ -3,28 +3,26 @@
 module Search
   # Component for generating hidden fields for search form attributes
   class FormHiddenFieldsComponent < ViewComponent::Base
-    def initialize(form_builder:, search_form:, form_field: nil, include_base_fields: true)
+    # @param form_builder [ActionView::Helpers::FormBuilder] The form builder for the search form
+    # @param search_form [SearchForm] The search form object containing the search parameters
+    # @param form_field [Symbol, nil] The specific form field to exclude from hidden
+    def initialize(form_builder:, search_form:, form_field: nil)
       @form_builder = form_builder
       @search_form = search_form
       # If form_field is provided, it will be excluded from the hidden fields.
       # Hidden fields will also be created for the fields from SearchForm (e.g., query).
       @form_field = form_field&.to_s
-      @include_base_fields = include_base_fields
       super()
     end
 
     attr_reader :form_builder, :search_form, :form_field
 
     def query_hidden_field?
-      search_form.query.present? && include_base_fields?
+      search_form.query.present? && form_field != 'query'
     end
 
     def include_google_books_hidden_field?
-      search_form.include_google_books && include_base_fields?
-    end
-
-    def include_base_fields?
-      @include_base_fields
+      search_form.include_google_books && form_field != 'include_google_books'
     end
   end
 end

--- a/app/javascript/controllers/form_submit_controller.js
+++ b/app/javascript/controllers/form_submit_controller.js
@@ -1,6 +1,5 @@
 import { Controller } from '@hotwired/stimulus'
 
-// Applies a facet search after the user selects a value.
 export default class extends Controller {
   submit (event) {
     event.target.form.requestSubmit()

--- a/spec/components/search/facet_search_component_spec.rb
+++ b/spec/components/search/facet_search_component_spec.rb
@@ -10,7 +10,7 @@ RSpec.describe Search::FacetSearchComponent, type: :component do
   it 'renders the facet search input' do
     render_inline(component)
 
-    expect(page).to have_css('div[data-controller="autocomplete facet-search"][data-autocomplete-url-value=' \
+    expect(page).to have_css('div[data-controller="autocomplete form-submit"][data-autocomplete-url-value=' \
                              '"/search/tag_facets/search?query=test&tags%5B%5D=test+%3A+tag"]')
     expect(page).to have_field('Search these tags', type: 'text')
     expect(page).to have_css("form[action='/search'][method='get']")

--- a/spec/components/search/form_hidden_fields_component_spec.rb
+++ b/spec/components/search/form_hidden_fields_component_spec.rb
@@ -3,7 +3,7 @@
 require 'rails_helper'
 
 RSpec.describe Search::FormHiddenFieldsComponent, type: :component do
-  let(:component) { described_class.new(search_form:, form_field:, form_builder:, include_base_fields:) }
+  let(:component) { described_class.new(search_form:, form_field:, form_builder:) }
   let(:form_builder) { ActionView::Helpers::FormBuilder.new(nil, search_form, vc_test_controller.view_context, {}) }
   let(:search_form) do
     SearchForm.new(object_types: %w[collection item],
@@ -13,7 +13,6 @@ RSpec.describe Search::FormHiddenFieldsComponent, type: :component do
                    include_google_books: true)
   end
   let(:form_field) { :object_types }
-  let(:include_base_fields) { true }
 
   context 'when rendering hidden fields for a facet field' do
     it 'renders hidden fields for other search form attributes' do
@@ -42,14 +41,22 @@ RSpec.describe Search::FormHiddenFieldsComponent, type: :component do
     end
   end
 
-  context 'when excluding base fields' do
-    let(:include_base_fields) { false }
+  context 'when excluding query' do
+    let(:form_field) { :query }
 
-    it 'does not render hidden fields for base fields' do
+    it 'does not render hidden field' do
       render_inline(component)
 
-      expect(page).to have_no_field('page', type: 'hidden')
       expect(page).to have_no_field('query', type: 'hidden')
+    end
+  end
+
+  context 'when excluding include google books' do
+    let(:form_field) { :include_google_books }
+
+    it 'does not render hidden field' do
+      render_inline(component)
+
       expect(page).to have_no_field('include_google_books', type: 'hidden')
     end
   end

--- a/spec/system/search/item_search_spec.rb
+++ b/spec/system/search/item_search_spec.rb
@@ -72,13 +72,27 @@ RSpec.describe 'Item search', :solr do
       it 'shows google books results' do
         visit root_path
 
-        check('Include Google Books')
-
         find_search_field.fill_in(with: 'Item')
         click_button('Search')
 
         within(find_item_results_section) do
+          expect(page).to have_result_count(11)
+        end
+
+        check('Include Google Books')
+
+        expect(page).to have_current_filter('Include Google Books')
+
+        within(find_item_results_section) do
           expect(page).to have_result_count(12)
+        end
+
+        uncheck('Include Google Books')
+
+        expect(page).not_to have_current_filter('Include Google Books')
+
+        within(find_item_results_section) do
+          expect(page).to have_result_count(11)
         end
       end
     end


### PR DESCRIPTION
closes #73

This provides a better user experience by not requiring the user to have to click search to apply "include google books".