### PR TITLE
Fix minor rubocop warning about namespace

### DIFF
--- a/app/services/sdr/version_service.rb
+++ b/app/services/sdr/version_service.rb
@@ -4,7 +4,7 @@ module Sdr
   # Encapsulates all version-related functionality
   class VersionService
     class << self
-      # @returns [Cocina::Models::DROWithMetadata|CollectionWithMetadata|AdminPolicyWithMetadata] cocina object with updated version # rubocop:disable Metrics/LineLength
+      # @returns [Cocina::Models::DROWithMetadata|CollectionWithMetadata|AdminPolicyWithMetadata] cocina object with updated version # rubocop:disable Layout/LineLength
       def open(druid:, **)
         new(druid:).open(**)
       end


### PR DESCRIPTION
I happened to notice this minor warning:

```
app/services/sdr/version_service.rb: Metrics/LineLength has the wrong namespace - replace it with Layout/LineLength
```
