### PR TITLE
[HOLD] Add an automated rubocop agent and workflow to capture new cop noise

### DIFF
--- a/.github/agents/rubocop-updater.agent.md
+++ b/.github/agents/rubocop-updater.agent.md
@@ -1,0 +1,73 @@
+---
+name: rubocop-updater
+description: Enables new Rubocop cops, autocorrects, attempts fixes, disables with comment if tests fail
+tools: [read, search, edit, terminal]
+---
+
+You are a Rubocop configuration and Rails code quality specialist.
+
+## Your job
+Given a list of new Rubocop cops in the issue, work through each cop
+in sequence using the process below. Do not skip steps or work on
+multiple cops simultaneously.
+
+## Process — follow this exactly for each cop
+
+### Step 1 — Enable the cop
+In .rubocop.yml, add the cop under its correct department with:
+  Enabled: true
+
+### Step 2 — Autocorrect
+Run:
+  bundle exec rubocop --only CopDepartment/CopName --autocorrect
+
+Note which files were corrected and which still have violations.
+
+### Step 3a — If violations remain after autocorrect
+Attempt to fix remaining violations manually by editing the
+offending files. Make the minimum change necessary to satisfy
+the cop. Do not refactor beyond what the cop requires.
+
+### Step 4 — Run the test suite
+After autocorrect and any manual fixes, run:
+  bundle exec rspec --format progress
+
+### Step 5 — Evaluate result
+
+IF tests pass:
+  Leave Enabled: true
+  Move to the next cop
+
+IF tests fail:
+  - Revert all code changes made for this cop (not the .rubocop.yml change)
+  - In .rubocop.yml change the entry to:
+      Enabled: false
+      # causes {relative path to first failing spec} to fail
+  - Move to the next cop
+
+## Files the agent may not touch
+- db/migrate/
+- config/
+- Any file not flagged by rubocop for this specific cop
+
+## Rules
+- Work through cops one at a time — complete all steps before starting the next
+- Never leave the codebase in a state where rubocop or rspec won't run
+- Preserve all existing .rubocop.yml configuration exactly
+- Only touch code files when fixing violations for the current cop
+- Revert code changes cleanly if disabling — .rubocop.yml comment is the only record
+- Keep manual fixes minimal — satisfy the cop, do not improve surrounding code
+- If autocorrect produces a syntax error or rubocop crashes, disable the cop immediately
+
+## Autonomy
+Work through the full list without pausing for confirmation.
+If you encounter an unexpected situation not covered by these
+instructions, make the conservative choice (disable with comment)
+and note it in the PR description.
+
+## Done when
+- Every cop in the issue has been processed
+- bundle exec rubocop exits without config errors
+- bundle exec rspec passes (all enabled cops satisfied or disabled with comment)
+- A meaningful PR description lists each cop and its outcome: enabled+autocorrected,
+  enabled+manual fix, or disabled with reason

--- a/.github/agents/rubocop-updater.agent.md
+++ b/.github/agents/rubocop-updater.agent.md
@@ -1,6 +1,6 @@
 ---
 name: rubocop-updater
-description: Enables new Rubocop cops, autocorrects, attempts fixes, disables with comment if tests fail
+description: Enables new Rubocop cops, autocorrects, attempts fixes, disables if complex
 tools: [read, search, edit, terminal]
 ---
 
@@ -26,24 +26,8 @@ Note which files were corrected and which still have violations.
 ### Step 3a — If violations remain after autocorrect
 Attempt to fix remaining violations manually by editing the
 offending files. Make the minimum change necessary to satisfy
-the cop. Do not refactor beyond what the cop requires.
-
-### Step 4 — Run the test suite
-After autocorrect and any manual fixes, run:
-  bundle exec rspec --format progress
-
-### Step 5 — Evaluate result
-
-IF tests pass:
-  Leave Enabled: true
-  Move to the next cop
-
-IF tests fail:
-  - Revert all code changes made for this cop (not the .rubocop.yml change)
-  - In .rubocop.yml change the entry to:
-      Enabled: false
-      # causes {relative path to first failing spec} to fail
-  - Move to the next cop
+the cop. Do not refactor beyond what the cop requires. If unable
+to satisfy the cop, set `Enabled: false`
 
 ## Files the agent may not touch
 - db/migrate/
@@ -52,7 +36,7 @@ IF tests fail:
 
 ## Rules
 - Work through cops one at a time — complete all steps before starting the next
-- Never leave the codebase in a state where rubocop or rspec won't run
+- Never leave the codebase in a state where rubocop won't run
 - Preserve all existing .rubocop.yml configuration exactly
 - Only touch code files when fixing violations for the current cop
 - Revert code changes cleanly if disabling — .rubocop.yml comment is the only record
@@ -68,6 +52,5 @@ and note it in the PR description.
 ## Done when
 - Every cop in the issue has been processed
 - bundle exec rubocop exits without config errors
-- bundle exec rspec passes (all enabled cops satisfied or disabled with comment)
 - A meaningful PR description lists each cop and its outcome: enabled+autocorrected,
   enabled+manual fix, or disabled with reason

--- a/.github/workflows/rubocop-cop-check.yml
+++ b/.github/workflows/rubocop-cop-check.yml
@@ -1,0 +1,77 @@
+# .github/workflows/rubocop-cop-check.yml
+# NOTE: workflow_dispatch inputs are used for manual runs while testing
+# and will be removed after confirmation.
+name: Detect new Rubocop cops
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - "Gemfile.lock"
+  workflow_dispatch:
+    inputs:
+      previous_version:
+        description: "Previous rubocop version"
+        required: true
+      current_version:
+        description: "Current rubocop version"
+        required: true
+permissions:
+  issues: write
+  contents: read
+jobs:
+  check-rubocop-cops:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 2
+
+      - name: Check for rubocop version change
+        id: version_check
+        run: |
+          PREV=$(git show HEAD~1:Gemfile.lock | grep "    rubocop " | awk '{print $2}')
+          CURR=$(grep "    rubocop " Gemfile.lock | awk '{print $2}')
+          echo "previous=$PREV" >> $GITHUB_OUTPUT
+          echo "current=$CURR" >> $GITHUB_OUTPUT
+          if [ "$PREV" != "$CURR" ]; then
+            echo "changed=true" >> $GITHUB_OUTPUT
+          else
+            echo "changed=false" >> $GITHUB_OUTPUT
+          fi
+
+      - name: Fetch new cops from changelog
+        id: new_cops
+        if: steps.version_check.outputs.changed == 'true'
+        run: |
+          # Pull rubocop changelog and extract cops added between versions
+          gem install rubocop --version ${{ steps.version_check.outputs.current }} --no-document
+          NEW_COPS=$(ruby -e "
+            require 'rubocop'
+            # Compare available cops against what's in .rubocop.yml
+            configured = File.read('.rubocop.yml')
+            all_cops = RuboCop::Cop::Registry.global.cops.map(&:cop_name)
+            new_cops = all_cops.reject { |c| configured.include?(c) }
+            puts new_cops.join('\n')
+          ")
+          echo "cops<<EOF" >> $GITHUB_OUTPUT
+          echo "$NEW_COPS" >> $GITHUB_OUTPUT
+          echo "EOF" >> $GITHUB_OUTPUT
+
+      - name: Create issue and assign to Copilot
+        if: steps.version_check.outputs.changed == 'true'
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          gh issue create \
+            --title "Rubocop updated ${{ steps.version_check.outputs.previous }} → ${{ steps.version_check.outputs.current }}: add new cops to .rubocop.yml" \
+            --body "## New cops to configure
+          Rubocop was updated and the following cops are not yet in .rubocop.yml:
+
+          ${{ steps.new_cops.outputs.cops }}
+
+          ## Instructions
+          Add each cop to .rubocop.yml with \`Enabled: false\` under the correct department.
+          Preserve all existing configuration. Run rubocop to verify the config is valid." \
+            --assignee "@copilot" \
+            --label "rubocop,maintenance"


### PR DESCRIPTION
In an effort to continue to improve our lives, particularly for noisy things like "new cops" installed output when running rubocop, this adds:

- An agent that reads a list of new cops from a ticket that is assigned to copilot and enables the cop, tries to address complaints, and disables the cop if the corrections are problematic
- An automated workflow that acts on each merge to `main` to detect if the version of rubocop was updated, what changed, and then open a ticket with any new cops, assigns the ticket to copilot to automate the agent above.

For now, the `workflow_dispatch` block of the workflow is so that this run without an update to robocop for testing so that we don't have to jump through hoops to test a version change.