### PR TITLE
[Proof-of-concept] Implement a Cocina description editor

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -38,7 +38,7 @@ Metrics/BlockLength:
     - 'config/routes.rb'
 
 Metrics/ClassLength:
-  Max: 150 # default 100
+  Max: 200 # default 100
 
 Metrics/MethodLength:
   CountAsOne:

--- a/app/controllers/descriptions_controller.rb
+++ b/app/controllers/descriptions_controller.rb
@@ -1,0 +1,153 @@
+# frozen_string_literal: true
+
+# Controller for editing the descriptive metadata of an object.
+class DescriptionsController < ApplicationController
+  before_action :load_cocina_object
+
+  FIELD_RESULT_KEY = {
+    'title' => :title, 'note' => :note, 'language' => :language,
+    'contributor' => :contributor, 'subject' => :subject, 'form' => :form,
+    'event' => :event, 'related_resource' => :relatedResource
+  }.freeze
+
+  FIELD_MODEL_CLASS = {
+    'title' => Cocina::Models::Title,
+    'note' => Cocina::Models::DescriptiveValue,
+    'language' => Cocina::Models::Language,
+    'contributor' => Cocina::Models::Contributor,
+    'subject' => Cocina::Models::DescriptiveValue,
+    'form' => Cocina::Models::DescriptiveValue,
+    'event' => Cocina::Models::Event,
+    'related_resource' => Cocina::Models::RelatedResource
+  }.freeze
+
+  def edit
+    authorize! @cocina_object, with: ObjectPolicy, to: :edit_description?
+    open_version_if_needed!
+  rescue Sdr::Repository::Error
+    # If pre-opening fails, save will attempt it again
+  end
+
+  # rubocop:disable Metrics/AbcSize
+  def field_json
+    authorize! @cocina_object, with: ObjectPolicy, to: :edit_description?
+
+    result_key = FIELD_RESULT_KEY[params.require(:field_type)]
+    return head :bad_request unless result_key
+
+    built = DescriptionBuilder.new(existing_description: {}).build(description_params)
+    item = built[result_key]&.first
+    return head(:unprocessable_content) unless item
+
+    render json: FIELD_MODEL_CLASS[params[:field_type]].new(item).to_h
+  rescue ActionController::ParameterMissing, JSON::ParserError,
+         Cocina::Models::ValidationError, Dry::Struct::Error
+    head :unprocessable_content
+  end
+  # rubocop:enable Metrics/AbcSize
+
+  def render_field
+    authorize! @cocina_object, with: ObjectPolicy, to: :edit_description?
+
+    data = JSON.parse(params.require(:json)).deep_symbolize_keys
+    result = field_partial_config(params.require(:field_type), data)
+    return head :bad_request unless result
+
+    render partial: result[:partial], locals: result[:locals]
+  rescue JSON::ParserError, Cocina::Models::ValidationError, Dry::Struct::Error
+    head :unprocessable_content
+  end
+
+  def update
+    authorize! @cocina_object, with: ObjectPolicy, to: :edit_description?
+
+    new_description = build_description
+    validate_result = CocinaSupport.validate(@cocina_object, description: new_description)
+
+    if validate_result.failure?
+      flash.now[:warning] = validate_result.failure
+      render :edit, status: :unprocessable_content
+      return
+    end
+
+    save_description!(new_description)
+  rescue Sdr::Repository::Error => e
+    flash.now[:warning] = e.message
+    render :edit, status: :unprocessable_content
+  end
+
+  private
+
+  def load_cocina_object
+    @cocina_object = Sdr::Repository.find(druid: params.expect(:object_druid))
+  rescue Sdr::Repository::NotFoundResponse
+    redirect_to root_path, flash: { warning: 'Object not found.' }
+  end
+
+  def open_version_if_needed!
+    return if Sdr::VersionService.open?(druid: @cocina_object.externalIdentifier)
+
+    Sdr::VersionService.open(druid: @cocina_object.externalIdentifier,
+                             description: 'Descriptive metadata edited via web form',
+                             opening_user_name: current_user.sunetid)
+  rescue Dor::Services::Client::Error => e
+    raise Sdr::Repository::Error, "Opening version failed: #{e.message}"
+  end
+
+  def close_version!
+    druid = @cocina_object.externalIdentifier
+    Sdr::VersionService.close(druid:) if Sdr::VersionService.closeable?(druid:)
+  rescue Dor::Services::Client::Error => e
+    raise Sdr::Repository::Error, "Closing version failed: #{e.message}"
+  end
+
+  def save_description!(new_description)
+    open_version_if_needed!
+    updated_object = @cocina_object.new(description: new_description)
+    Sdr::Repository.update(cocina_object: updated_object,
+                           user_name: current_user.sunetid,
+                           description: 'Descriptive metadata edited via web form')
+    close_version!
+    redirect_to object_path(druid: @cocina_object.externalIdentifier), flash: { success: 'Description updated.' }
+  end
+
+  # rubocop:disable Metrics/CyclomaticComplexity
+  def field_partial_config(field_type, data)
+    case field_type
+    when 'title'       then { partial: 'descriptions/title_fields',
+                              locals: { title: Cocina::Models::Title.new(data) } }
+    when 'note'        then { partial: 'descriptions/note_fields',
+                              locals: { note: Cocina::Models::DescriptiveValue.new(data) } }
+    when 'language'    then { partial: 'descriptions/language_fields',
+                              locals: { language: Cocina::Models::Language.new(data) } }
+    when 'contributor' then { partial: 'descriptions/contributor_fields', locals: { contributor: data } }
+    when 'subject'     then { partial: 'descriptions/subject_fields',     locals: { subject: data } }
+    when 'form'        then { partial: 'descriptions/form_fields',         locals: { form: data } }
+    when 'event'       then { partial: 'descriptions/event_fields',        locals: { event: data } }
+    when 'related_resource' then { partial: 'descriptions/related_resource_fields',
+                                   locals: { related_resource: data } }
+    end
+  end
+  # rubocop:enable Metrics/CyclomaticComplexity
+
+  def build_description
+    DescriptionBuilder.new(existing_description: @cocina_object.description.to_h)
+                      .build(description_params)
+  end
+
+  # rubocop:disable Rails/StrongParametersExpect
+  def description_params
+    params.require(:description).permit(
+      title: [:value, :type, :_raw_json, :_original, { struct_parts: %i[value type] }],
+      note: %i[value type _raw_json],
+      language: %i[code value _raw_json],
+      contributor: %i[_raw_json _original name_value life_dates type primary role_value],
+      subject: [:_raw_json, :value, :type, :source_code, :_struct_original, { struct_parts: %i[value type] }],
+      form: %i[_raw_json value type source_code],
+      event: %i[_raw_json _original date_value date_start_value date_end_value type place_value publisher_value],
+      related_resource: %i[_raw_json title_value type url],
+      access: { physical_location: %i[value type], access_contact: %i[value type] }
+    ).to_h.deep_symbolize_keys
+  end
+  # rubocop:enable Rails/StrongParametersExpect
+end

--- a/app/controllers/descriptions_controller.rb
+++ b/app/controllers/descriptions_controller.rb
@@ -23,9 +23,8 @@ class DescriptionsController < ApplicationController
 
   def edit
     authorize! @cocina_object, with: ObjectPolicy, to: :edit_description?
-    open_version_if_needed!
-  rescue Sdr::Repository::Error
-    # If pre-opening fails, save will attempt it again
+    # A version is opened at save time, not on display, to avoid creating dangling
+    # versions when the edit form is loaded but never submitted.
   end
 
   # rubocop:disable Metrics/AbcSize
@@ -87,9 +86,11 @@ class DescriptionsController < ApplicationController
   def open_version_if_needed!
     return if Sdr::VersionService.open?(druid: @cocina_object.externalIdentifier)
 
-    Sdr::VersionService.open(druid: @cocina_object.externalIdentifier,
-                             description: 'Descriptive metadata edited via web form',
-                             opening_user_name: current_user.sunetid)
+    # Opening creates a new version; replace @cocina_object with the returned object so a
+    # subsequent update sends the new version and lock rather than the now-stale ones.
+    @cocina_object = Sdr::VersionService.open(druid: @cocina_object.externalIdentifier,
+                                              description: 'Descriptive metadata edited via web form',
+                                              opening_user_name: current_user.sunetid)
   rescue Dor::Services::Client::Error => e
     raise Sdr::Repository::Error, "Opening version failed: #{e.message}"
   end

--- a/app/javascript/controllers/cocina_model_show_controller.js
+++ b/app/javascript/controllers/cocina_model_show_controller.js
@@ -61,7 +61,8 @@ export default class extends Controller {
       this.frameReloadTimeouts = []
 
       // Reload frames one at a time to spread out requests and reduce bursts.
-      frames.forEach((frame, index) => {
+      // Skip frames containing forms — reloading would discard the user's unsaved input.
+      frames.filter(frame => !frame.querySelector('form')).forEach((frame, index) => {
         const timeoutId = setTimeout(() => {
           if (document.visibilityState === 'visible') frame.reload()
         }, index * this.staggerValue)

--- a/app/javascript/controllers/description_editor_controller.js
+++ b/app/javascript/controllers/description_editor_controller.js
@@ -1,0 +1,16 @@
+import { Controller } from '@hotwired/stimulus'
+
+// Manages the dynamic addition and removal of array items in the description editor.
+export default class extends Controller {
+  addItem (event) {
+    event.preventDefault()
+    const list = document.getElementById(event.currentTarget.dataset.listId)
+    const template = document.getElementById(event.currentTarget.dataset.templateId)
+    list.appendChild(template.content.cloneNode(true))
+  }
+
+  removeItem (event) {
+    event.preventDefault()
+    event.currentTarget.closest('[data-item]').remove()
+  }
+}

--- a/app/javascript/controllers/description_field_controller.js
+++ b/app/javascript/controllers/description_field_controller.js
@@ -1,0 +1,51 @@
+import { Controller } from '@hotwired/stimulus'
+
+export default class extends Controller {
+  #debounceTimer = null
+  #handleChange = (event) => {
+    // Ignore hidden inputs and the JSON textarea itself (that syncs the other direction)
+    if (event.target.type === 'hidden') return
+    if (event.target.closest('[data-controller~="json-formatter"]')) return
+
+    clearTimeout(this.#debounceTimer)
+    this.#debounceTimer = setTimeout(() => this.#sendUpdate(), 400)
+  }
+
+  connect () {
+    this.element.addEventListener('input', this.#handleChange)
+    this.element.addEventListener('change', this.#handleChange)
+  }
+
+  disconnect () {
+    this.element.removeEventListener('input', this.#handleChange)
+    this.element.removeEventListener('change', this.#handleChange)
+    clearTimeout(this.#debounceTimer)
+  }
+
+  #sendUpdate () {
+    const fieldType = this.element.dataset.fieldType
+    const urlContainer = this.element.closest('[data-field-json-url]')
+    if (!fieldType || !urlContainer) return
+
+    const csrfToken = document.querySelector('meta[name="csrf-token"]')?.content
+    const params = new URLSearchParams({ field_type: fieldType })
+    const selector = 'input:not([disabled]), select, textarea:not([disabled]):not([data-controller~="json-formatter"])'
+    this.element.querySelectorAll(selector).forEach(el => {
+      if (el.name) params.append(el.name, el.value)
+    })
+
+    fetch(urlContainer.dataset.fieldJsonUrl, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/x-www-form-urlencoded', 'X-CSRF-Token': csrfToken },
+      body: params.toString()
+    })
+      .then(response => response.ok ? response.json() : null)
+      .then(json => {
+        if (!json) return
+        const textarea = this.element.querySelector('[data-controller~="json-formatter"]')
+        if (!textarea) return
+        textarea.value = JSON.stringify(json, null, 2)
+      })
+      .catch(() => {})
+  }
+}

--- a/app/javascript/controllers/json_formatter_controller.js
+++ b/app/javascript/controllers/json_formatter_controller.js
@@ -1,0 +1,88 @@
+import { Controller } from '@hotwired/stimulus'
+
+export default class extends Controller {
+  #collapse = null
+  #onShow = () => { this.element.disabled = false }
+  #onShown = () => { this.resize() }
+  #onHide = () => { this.element.disabled = true }
+
+  connect () {
+    const collapse = this.element.closest('.collapse')
+    if (collapse) {
+      this.element.disabled = !collapse.classList.contains('show')
+      collapse.addEventListener('show.bs.collapse', this.#onShow)
+      collapse.addEventListener('shown.bs.collapse', this.#onShown)
+      collapse.addEventListener('hide.bs.collapse', this.#onHide)
+      this.#collapse = collapse
+    }
+    this.resize()
+  }
+
+  disconnect () {
+    if (this.#collapse) {
+      this.#collapse.removeEventListener('show.bs.collapse', this.#onShow)
+      this.#collapse.removeEventListener('shown.bs.collapse', this.#onShown)
+      this.#collapse.removeEventListener('hide.bs.collapse', this.#onHide)
+    }
+  }
+
+  resize () {
+    this.element.style.height = 'auto'
+    this.element.style.height = `${Math.max(this.element.scrollHeight, 160)}px`
+  }
+
+  format () {
+    try {
+      const parsed = JSON.parse(this.element.value)
+      this.element.value = JSON.stringify(parsed, null, 2)
+      this.element.classList.remove('is-invalid')
+      this.resize()
+      this.syncToForm()
+    } catch {
+      this.element.classList.add('is-invalid')
+    }
+  }
+
+  syncToForm () {
+    // Only sync json_toggle textareas (inside .collapse), not the "must edit as JSON" fallback ones
+    const collapse = this.element.closest('.collapse')
+    if (!collapse) return
+
+    const dataItem = this.element.closest('[data-item]')
+    if (!dataItem) return
+
+    const fieldType = dataItem.dataset.fieldType
+    if (!fieldType) return
+
+    const urlContainer = this.element.closest('[data-render-field-url]')
+    if (!urlContainer) return
+
+    const url = urlContainer.dataset.renderFieldUrl
+    const csrfToken = document.querySelector('meta[name="csrf-token"]')?.content
+
+    fetch(url, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json', 'X-CSRF-Token': csrfToken },
+      body: JSON.stringify({ field_type: fieldType, json: this.element.value })
+    })
+      .then(response => response.ok ? response.text() : null)
+      .then(html => {
+        if (!html) return
+        const temp = document.createElement('div')
+        temp.innerHTML = html
+        const newItem = temp.firstElementChild
+        if (!newItem) return
+
+        // Re-open the collapse so the user can keep editing
+        const newCollapse = newItem.querySelector('.collapse')
+        if (newCollapse) {
+          newCollapse.classList.add('show')
+          const toggleBtn = newItem.querySelector('[data-bs-toggle="collapse"]')
+          if (toggleBtn) toggleBtn.setAttribute('aria-expanded', 'true')
+        }
+
+        dataItem.replaceWith(newItem)
+      })
+      .catch(() => {})
+  }
+}

--- a/app/policies/object_policy.rb
+++ b/app/policies/object_policy.rb
@@ -12,4 +12,8 @@ class ObjectPolicy < ApplicationPolicy
   def edit?
     false
   end
+
+  def edit_description?
+    admin?
+  end
 end

--- a/app/services/description_builder.rb
+++ b/app/services/description_builder.rb
@@ -1,0 +1,246 @@
+# frozen_string_literal: true
+
+# Merges submitted form params into an existing Cocina description hash,
+# preserving fields not yet exposed by the editor.
+class DescriptionBuilder
+  def initialize(existing_description:)
+    @existing = existing_description
+  end
+
+  # rubocop:disable Metrics/AbcSize, Metrics/CyclomaticComplexity, Metrics/PerceivedComplexity
+  def build(submitted)
+    titles = submitted[:title]&.filter_map { |t| build_title(t) }
+    notes = submitted[:note]&.filter_map { |n| build_note(n) }
+    languages = submitted[:language]&.filter_map { |l| build_language(l) }
+    contributors = submitted[:contributor]&.filter_map { |c| build_contributor(c) }
+    subjects = submitted[:subject]&.filter_map { |s| build_subject(s) }
+    forms = submitted[:form]&.filter_map { |f| build_form(f) }
+    events = submitted[:event]&.filter_map { |e| build_event(e) }
+    related_resources = submitted[:related_resource]&.filter_map { |r| build_related_resource(r) }
+    access = build_access(submitted[:access])
+
+    @existing.merge(
+      title: titles.presence || @existing[:title],
+      note: notes.presence || @existing[:note],
+      language: languages.presence || @existing[:language],
+      contributor: contributors.presence || @existing[:contributor],
+      subject: subjects.presence || @existing[:subject],
+      form: forms.presence || @existing[:form],
+      event: events.presence || @existing[:event],
+      relatedResource: related_resources.presence || @existing[:relatedResource],
+      access: access || @existing[:access]
+    ).compact
+  end
+  # rubocop:enable Metrics/AbcSize, Metrics/CyclomaticComplexity, Metrics/PerceivedComplexity
+
+  private
+
+  def build_note(params)
+    return safe_parse_json(params[:_raw_json]) if params[:_raw_json].present?
+
+    compact_entry(params, required: :value)
+  end
+
+  def build_language(params)
+    return safe_parse_json(params[:_raw_json]) if params[:_raw_json].present?
+
+    compact_entry(params, required: :code)
+  end
+
+  def build_title(params)
+    return safe_parse_json(params[:_raw_json]) if params[:_raw_json].present?
+
+    if params[:struct_parts].present?
+      build_structured_title(params)
+    else
+      compact_entry({ value: params[:value], type: params[:type] }, required: :value)
+    end
+  end
+
+  def build_structured_title(params)
+    base = params[:_original].present? ? (safe_parse_json(params[:_original]) || {}) : {}
+    parts = params[:struct_parts].filter_map { |p| compact_entry(p, required: :value) }
+    return nil if parts.empty?
+
+    result = base.merge(structuredValue: parts)
+    params[:type].present? ? result[:type] = params[:type] : result.delete(:type)
+    result
+  end
+
+  # rubocop:disable Metrics/AbcSize
+  def build_contributor(params)
+    return safe_parse_json(params[:_raw_json]) if params[:_raw_json].present?
+    return nil if params[:name_value].blank?
+
+    base = params[:_original].present? ? safe_parse_json(params[:_original]) : {}
+    return nil if base.nil?
+
+    result = base.merge(name: [build_contributor_name(params)])
+    result[:type] = params[:type] if params[:type].present?
+    apply_contributor_status(result, params)
+    apply_contributor_role(result, base, params)
+    result
+  end
+  # rubocop:enable Metrics/AbcSize
+
+  def build_contributor_name(params)
+    if params[:life_dates].present?
+      { structuredValue: [{ value: params[:name_value], type: 'name' },
+                          { value: params[:life_dates], type: 'life dates' }] }
+    else
+      { value: params[:name_value] }
+    end
+  end
+
+  def apply_contributor_status(result, params)
+    if params[:primary] == '1'
+      result[:status] = 'primary'
+    else
+      result.delete(:status)
+    end
+  end
+
+  # Update the first role's display value while preserving code/uri/source from _original.
+  def apply_contributor_role(result, base, params)
+    return if params[:role_value].blank?
+
+    existing_role = base.dig(:role, 0) || {}
+    result[:role] = [existing_role.merge(value: params[:role_value])]
+  end
+
+  def build_subject(params)
+    return safe_parse_json(params[:_raw_json]) if params[:_raw_json].present?
+
+    if params[:struct_parts].present?
+      build_structured_subject(params)
+    else
+      build_simple_subject(params)
+    end
+  end
+
+  def build_structured_subject(params)
+    base = params[:_struct_original].present? ? (safe_parse_json(params[:_struct_original]) || {}) : {}
+    parts = params[:struct_parts].filter_map { |p| compact_entry(p, required: :value) }
+    return nil if parts.empty?
+
+    base.merge(structuredValue: parts)
+  end
+
+  def build_simple_subject(params)
+    return nil if params[:value].blank?
+
+    entry = { value: params[:value] }
+    entry[:type] = params[:type] if params[:type].present?
+    entry[:source] = { code: params[:source_code] } if params[:source_code].present?
+    entry
+  end
+
+  def build_form(params)
+    return safe_parse_json(params[:_raw_json]) if params[:_raw_json].present?
+    return nil if params[:value].blank?
+
+    entry = { value: params[:value] }
+    entry[:type] = params[:type] if params[:type].present?
+    entry[:source] = { code: params[:source_code] } if params[:source_code].present?
+    entry
+  end
+
+  # rubocop:disable Metrics/AbcSize
+  def build_event(params)
+    return safe_parse_json(params[:_raw_json]) if params[:_raw_json].present?
+    return nil if params[:date_value].blank? && params[:type].blank?
+
+    base = params[:_original].present? ? (safe_parse_json(params[:_original]) || {}) : {}
+    result = base.dup
+    apply_event_type(result, params)
+    apply_event_date(result, base, params)
+    apply_event_location(result, base, params)
+    apply_event_publisher(result, base, params)
+    result
+  end
+  # rubocop:enable Metrics/AbcSize
+
+  def apply_event_type(result, params)
+    params[:type].present? ? result[:type] = params[:type] : result.delete(:type)
+  end
+
+  # rubocop:disable Metrics/AbcSize
+  def apply_event_date(result, base, params)
+    existing_date = base.dig(:date, 0) || {}
+
+    if params[:date_start_value].present? || params[:date_end_value].present?
+      structured = []
+      structured << { value: params[:date_start_value], type: 'start' } if params[:date_start_value].present?
+      structured << { value: params[:date_end_value], type: 'end' } if params[:date_end_value].present?
+      result[:date] = [existing_date.merge(structuredValue: structured)]
+    elsif params[:date_value].present?
+      result[:date] = [existing_date.merge(value: params[:date_value])]
+    end
+  end
+  # rubocop:enable Metrics/AbcSize
+
+  def apply_event_location(result, base, params)
+    return if params[:place_value].blank?
+
+    # Preserve all original locations (e.g. value + MARC country code pair);
+    # update only the first entry that has a value field.
+    locs = base[:location]&.dup || []
+    idx = locs.index { |l| l[:value].present? } || 0
+    locs[idx] = (locs[idx] || {}).merge(value: params[:place_value])
+    result[:location] = locs
+  end
+
+  def apply_event_publisher(result, base, params)
+    if params[:publisher_value].present?
+      existing_contributor = base.dig(:contributor, 0) || {}
+      existing_name = existing_contributor.dig(:name, 0) || {}
+      result[:contributor] = [existing_contributor.merge(
+        type: existing_contributor[:type] || 'organization',
+        name: [existing_name.merge(value: params[:publisher_value])],
+        role: existing_contributor[:role].presence || [{ value: 'publisher' }]
+      )]
+    elsif base[:contributor].blank?
+      result.delete(:contributor)
+    end
+  end
+
+  # rubocop:disable Metrics/AbcSize
+  def build_related_resource(params)
+    return safe_parse_json(params[:_raw_json]) if params[:_raw_json].present?
+    return nil if params[:title_value].blank? && params[:url].blank?
+
+    entry = {}
+    entry[:type] = params[:type] if params[:type].present?
+    entry[:title] = [{ value: params[:title_value] }] if params[:title_value].present?
+    entry[:access] = { url: [{ value: params[:url] }] } if params[:url].present?
+    entry
+  end
+  # rubocop:enable Metrics/AbcSize
+
+  # rubocop:disable Metrics/AbcSize, Metrics/CyclomaticComplexity
+  def build_access(params)
+    return nil if params.blank?
+
+    existing_access = @existing.fetch(:access, {})
+    physical_locations = params[:physical_location]&.filter_map { |pl| compact_entry(pl, required: :value) }
+    access_contacts = params[:access_contact]&.filter_map { |ac| compact_entry(ac, required: :value) }
+
+    existing_access.merge(
+      physicalLocation: physical_locations.presence || existing_access[:physicalLocation],
+      accessContact: access_contacts.presence || existing_access[:accessContact]
+    ).compact.presence
+  end
+  # rubocop:enable Metrics/AbcSize, Metrics/CyclomaticComplexity
+
+  def safe_parse_json(str)
+    JSON.parse(str).deep_symbolize_keys
+  rescue JSON::ParserError
+    nil
+  end
+
+  def compact_entry(hash, required:)
+    return nil if hash[required].blank?
+
+    hash.compact_blank
+  end
+end

--- a/app/services/description_builder.rb
+++ b/app/services/description_builder.rb
@@ -19,16 +19,20 @@ class DescriptionBuilder
     related_resources = submitted[:related_resource]&.filter_map { |r| build_related_resource(r) }
     access = build_access(submitted[:access])
 
+    # The editor renders every section pre-populated with all existing items, so the
+    # submitted form is the authoritative state for these fields. An empty section means
+    # the user deleted all its items, so fall through to nil (compact drops the key) rather
+    # than restoring @existing. Unexposed fields are preserved by merging into @existing.
     @existing.merge(
-      title: titles.presence || @existing[:title],
-      note: notes.presence || @existing[:note],
-      language: languages.presence || @existing[:language],
-      contributor: contributors.presence || @existing[:contributor],
-      subject: subjects.presence || @existing[:subject],
-      form: forms.presence || @existing[:form],
-      event: events.presence || @existing[:event],
-      relatedResource: related_resources.presence || @existing[:relatedResource],
-      access: access || @existing[:access]
+      title: titles.presence,
+      note: notes.presence,
+      language: languages.presence,
+      contributor: contributors.presence,
+      subject: subjects.presence,
+      form: forms.presence,
+      event: events.presence,
+      relatedResource: related_resources.presence,
+      access:
     ).compact
   end
   # rubocop:enable Metrics/AbcSize, Metrics/CyclomaticComplexity, Metrics/PerceivedComplexity
@@ -72,8 +76,7 @@ class DescriptionBuilder
     return safe_parse_json(params[:_raw_json]) if params[:_raw_json].present?
     return nil if params[:name_value].blank?
 
-    base = params[:_original].present? ? safe_parse_json(params[:_original]) : {}
-    return nil if base.nil?
+    base = params[:_original].present? ? (safe_parse_json(params[:_original]) || {}) : {}
 
     result = base.merge(name: [build_contributor_name(params)])
     result[:type] = params[:type] if params[:type].present?
@@ -217,7 +220,6 @@ class DescriptionBuilder
   end
   # rubocop:enable Metrics/AbcSize
 
-  # rubocop:disable Metrics/AbcSize, Metrics/CyclomaticComplexity
   def build_access(params)
     return nil if params.blank?
 
@@ -226,14 +228,14 @@ class DescriptionBuilder
     access_contacts = params[:access_contact]&.filter_map { |ac| compact_entry(ac, required: :value) }
 
     existing_access.merge(
-      physicalLocation: physical_locations.presence || existing_access[:physicalLocation],
-      accessContact: access_contacts.presence || existing_access[:accessContact]
+      physicalLocation: physical_locations.presence,
+      accessContact: access_contacts.presence
     ).compact.presence
   end
-  # rubocop:enable Metrics/AbcSize, Metrics/CyclomaticComplexity
 
   def safe_parse_json(str)
-    JSON.parse(str).deep_symbolize_keys
+    parsed = JSON.parse(str)
+    parsed.respond_to?(:deep_symbolize_keys) ? parsed.deep_symbolize_keys : nil
   rescue JSON::ParserError
     nil
   end

--- a/app/services/descriptive_csv/validator.rb
+++ b/app/services/descriptive_csv/validator.rb
@@ -2,7 +2,7 @@
 
 module DescriptiveCsv
   # Validate the descriptive metadata spreadsheet
-  class Validator # rubocop:disable Metrics/ClassLength
+  class Validator
     def initialize(csv, bulk_job: false)
       @headers = csv.headers
       @bulk_job = bulk_job # indicates if validating from a bulk job

--- a/app/views/descriptions/_access_contact_fields.html.erb
+++ b/app/views/descriptions/_access_contact_fields.html.erb
@@ -1,0 +1,25 @@
+<div class="border rounded p-2 mb-2" data-item>
+  <div class="row g-2 align-items-center">
+    <div class="col">
+      <input type="text"
+             class="form-control"
+             name="description[access][access_contact][][value]"
+             value="<%= access_contact&.dig(:value) %>"
+             placeholder="Contact value (e.g. email or department name)"
+             aria-label="Access contact value">
+    </div>
+    <div class="col-auto">
+      <select class="form-select"
+              name="description[access][access_contact][][type]"
+              aria-label="Access contact type">
+        <option value="email"      <%= 'selected' if access_contact&.dig(:type) == 'email' %>>Email</option>
+        <option value="repository" <%= 'selected' if access_contact&.dig(:type) == 'repository' %>>Repository</option>
+      </select>
+    </div>
+    <div class="col-auto">
+      <button class="btn btn-sm btn-outline-danger"
+              data-action="description-editor#removeItem"
+              aria-label="Remove access contact">&times;</button>
+    </div>
+  </div>
+</div>

--- a/app/views/descriptions/_contributor_fields.html.erb
+++ b/app/views/descriptions/_contributor_fields.html.erb
@@ -1,0 +1,94 @@
+<%
+  # Determine contributor shape from the hash.
+  # Simple:    name[0].value present          → curated form
+  # Structured: name[0].structuredValue with name + life dates → curated form (two inputs)
+  # Complex:   anything else                  → raw JSON textarea
+  name_entry   = contributor&.dig(:name, 0) || {}
+  simple       = name_entry[:value].present?
+  life_dates   = name_entry[:structuredValue]&.find { |s| s[:type] == 'life dates' }&.dig(:value)
+  name_val     = simple ? name_entry[:value] : name_entry[:structuredValue]&.find { |s| s[:type] == 'name' }&.dig(:value)
+  structured   = !simple && name_val.present?
+  curated      = contributor.nil? || simple || structured
+  role_val     = contributor&.dig(:role, 0, :value)
+%>
+
+<div class="border rounded p-2 mb-2" data-item data-field-type="contributor" data-controller="description-field">
+  <% if curated %>
+    <%# Preserve full original JSON so role codes/URIs survive the round-trip %>
+    <input type="hidden" name="description[contributor][][_original]" value="<%= contributor.to_json %>">
+
+    <div class="row g-2 mb-2">
+      <div class="col">
+        <input type="text"
+               class="form-control"
+               name="description[contributor][][name_value]"
+               value="<%= name_val %>"
+               placeholder="Name"
+               aria-label="Contributor name">
+      </div>
+      <% if structured || life_dates.present? || contributor.nil? %>
+        <div class="col-auto">
+          <input type="text"
+                 class="form-control"
+                 name="description[contributor][][life_dates]"
+                 value="<%= life_dates %>"
+                 placeholder="Life dates (e.g. 1869-1939)"
+                 aria-label="Life dates"
+                 style="width: 14rem">
+        </div>
+      <% end %>
+      <div class="col-auto">
+        <select class="form-select" name="description[contributor][][type]" aria-label="Contributor type">
+          <option value="person"       <%= 'selected' if contributor&.dig(:type) == 'person' %>>Person</option>
+          <option value="organization" <%= 'selected' if contributor&.dig(:type) == 'organization' %>>Organization</option>
+          <option value="conference"   <%= 'selected' if contributor&.dig(:type) == 'conference' %>>Conference</option>
+        </select>
+      </div>
+      <div class="col-auto d-flex align-items-center gap-1">
+        <input class="form-check-input"
+               type="checkbox"
+               name="description[contributor][][primary]"
+               value="1"
+               id="primary-<%= contributor.object_id %>"
+               <%= 'checked' if contributor&.dig(:status) == 'primary' %>>
+        <label class="form-check-label small" for="primary-<%= contributor.object_id %>">Primary</label>
+      </div>
+      <div class="col-auto">
+        <button class="btn btn-sm btn-outline-danger"
+                data-action="description-editor#removeItem"
+                aria-label="Remove contributor">&times;</button>
+      </div>
+    </div>
+    <% if role_val.present? || contributor.nil? %>
+      <div class="row g-2">
+        <div class="col">
+          <input type="text"
+                 class="form-control"
+                 name="description[contributor][][role_value]"
+                 value="<%= role_val %>"
+                 placeholder="Role (e.g. author, editor, publisher)"
+                 aria-label="Role">
+        </div>
+      </div>
+    <% end %>
+    <%= render 'descriptions/json_toggle', json_data: contributor || {}, field_name: 'description[contributor][][_raw_json]' %>
+
+  <% else %>
+    <%# Complex contributor — raw JSON escape hatch %>
+    <div class="d-flex gap-2 align-items-start">
+      <div class="flex-grow-1">
+        <p class="small text-info-emphasis bg-info-subtle border border-info-subtle rounded px-2 py-1 mb-1">
+          This contributor has a complex name structure and must be edited as JSON.
+        </p>
+        <textarea rows="8" class="form-control font-monospace"
+                  name="description[contributor][][_raw_json]"
+                  aria-label="Contributor JSON"
+                  data-controller="json-formatter"
+                  data-action="blur->json-formatter#format"><%= JSON.pretty_generate(contributor) %></textarea>
+      </div>
+      <button class="btn btn-sm btn-outline-danger mt-4 flex-shrink-0"
+              data-action="description-editor#removeItem"
+              aria-label="Remove contributor">&times;</button>
+    </div>
+  <% end %>
+</div>

--- a/app/views/descriptions/_event_fields.html.erb
+++ b/app/views/descriptions/_event_fields.html.erb
@@ -1,0 +1,125 @@
+<%
+  if event.nil?
+    curated = true
+    date_range = false
+    event_type = date_val = date_start_val = date_end_val = place_val = publisher_val = nil
+  else
+    sv = event.dig(:date, 0, :structuredValue)
+    date_range         = sv.present? && sv.all? { |p| p[:type].in?(%w[start end]) }
+    complex_date       = !date_range && (sv.present? || event.dig(:date, 0, :parallelValue).present?)
+    has_parallel       = event[:parallelEvent].present?
+    simple_contributor = !event[:contributor].present? ||
+                         (event[:contributor].length == 1 &&
+                          event.dig(:contributor, 0, :name, 0, :value).present? &&
+                          event.dig(:contributor, 0, :name, 0, :structuredValue).blank?)
+    curated        = !complex_date && !has_parallel && simple_contributor
+    event_type     = event[:type].presence || event.dig(:date, 0, :type)
+    date_val       = event.dig(:date, 0, :value)
+    date_start_val = sv&.find { |p| p[:type] == 'start' }&.dig(:value)
+    date_end_val   = sv&.find { |p| p[:type] == 'end' }&.dig(:value)
+    place_val      = event.dig(:location, 0, :value)
+    publisher_val  = event.dig(:contributor, 0, :name, 0, :value)
+  end
+%>
+
+<div class="border rounded p-2 mb-2" data-item data-field-type="event" data-controller="description-field">
+  <% if curated %>
+    <%# Preserve full original JSON so location codes, date encoding, notes survive round-trip %>
+    <input type="hidden" name="description[event][][_original]" value="<%= event.to_json %>">
+
+    <div class="row g-2 mb-2 align-items-center">
+      <div class="col-auto">
+        <select class="form-select" name="description[event][][type]" aria-label="Event type">
+          <option value="">-- type --</option>
+          <option value="acquisition"      <%= 'selected' if event_type == 'acquisition' %>>Acquisition</option>
+          <option value="broadcast"        <%= 'selected' if event_type == 'broadcast' %>>Broadcast</option>
+          <option value="capture"          <%= 'selected' if event_type == 'capture' %>>Capture</option>
+          <option value="copyright"        <%= 'selected' if event_type == 'copyright' %>>Copyright</option>
+          <option value="creation"         <%= 'selected' if event_type == 'creation' %>>Creation</option>
+          <option value="degree conferral" <%= 'selected' if event_type == 'degree conferral' %>>Degree conferral</option>
+          <option value="deposit"          <%= 'selected' if event_type == 'deposit' %>>Deposit</option>
+          <option value="distribution"     <%= 'selected' if event_type == 'distribution' %>>Distribution</option>
+          <option value="manufacture"      <%= 'selected' if event_type == 'manufacture' %>>Manufacture</option>
+          <option value="performance"      <%= 'selected' if event_type == 'performance' %>>Performance</option>
+          <option value="production"       <%= 'selected' if event_type == 'production' %>>Production</option>
+          <option value="publication"      <%= 'selected' if event_type == 'publication' %>>Publication</option>
+        </select>
+      </div>
+      <% if date_range %>
+        <div class="col">
+          <input type="text"
+                 class="form-control"
+                 name="description[event][][date_start_value]"
+                 value="<%= date_start_val %>"
+                 placeholder="Start date"
+                 aria-label="Start date">
+        </div>
+        <div class="col">
+          <input type="text"
+                 class="form-control"
+                 name="description[event][][date_end_value]"
+                 value="<%= date_end_val %>"
+                 placeholder="End date"
+                 aria-label="End date">
+        </div>
+      <% else %>
+        <div class="col">
+          <input type="text"
+                 class="form-control"
+                 name="description[event][][date_value]"
+                 value="<%= date_val %>"
+                 placeholder="Date (e.g. 1978, 2001-06-15)"
+                 aria-label="Event date">
+        </div>
+      <% end %>
+      <div class="col-auto">
+        <button class="btn btn-sm btn-outline-danger"
+                data-action="description-editor#removeItem"
+                aria-label="Remove event">&times;</button>
+      </div>
+    </div>
+    <div class="row g-2 align-items-center">
+      <div class="col">
+        <input type="text"
+               class="form-control"
+               name="description[event][][publisher_value]"
+               value="<%= publisher_val %>"
+               placeholder="Publisher (optional)"
+               aria-label="Publisher">
+      </div>
+      <div class="col">
+        <input type="text"
+               class="form-control"
+               name="description[event][][place_value]"
+               value="<%= place_val %>"
+               placeholder="Place (e.g. New York)"
+               aria-label="Event place">
+      </div>
+    </div>
+    <%= render 'descriptions/json_toggle', json_data: event || {}, field_name: 'description[event][][_raw_json]' %>
+
+  <% else %>
+    <%# Complex event (parallelEvent, structured date range, multi-contributor) — raw JSON escape hatch %>
+    <%
+      reasons = []
+      reasons << 'structured or parallel date range' if complex_date
+      reasons << 'parallel event values' if has_parallel
+      reasons << 'multiple or complex contributors' unless simple_contributor
+    %>
+    <div class="d-flex gap-2 align-items-start">
+      <div class="flex-grow-1">
+        <p class="small text-info-emphasis bg-info-subtle border border-info-subtle rounded px-2 py-1 mb-1">
+          This event contains <%= reasons.to_sentence %> and must be edited as JSON.
+        </p>
+        <textarea rows="8" class="form-control font-monospace"
+                  name="description[event][][_raw_json]"
+                  aria-label="Event JSON"
+                  data-controller="json-formatter"
+                  data-action="blur->json-formatter#format"><%= JSON.pretty_generate(event) %></textarea>
+      </div>
+      <button class="btn btn-sm btn-outline-danger mt-4 flex-shrink-0"
+              data-action="description-editor#removeItem"
+              aria-label="Remove event">&times;</button>
+    </div>
+  <% end %>
+</div>

--- a/app/views/descriptions/_form_fields.html.erb
+++ b/app/views/descriptions/_form_fields.html.erb
@@ -1,0 +1,65 @@
+<%
+  curated = form.nil? || (form.dig(:value).present? && form.dig(:structuredValue).blank?)
+%>
+
+<div class="border rounded p-2 mb-2" data-item data-field-type="form" data-controller="description-field">
+  <% if curated %>
+    <div class="row g-2 align-items-center">
+      <div class="col">
+        <input type="text"
+               class="form-control"
+               name="description[form][][value]"
+               value="<%= form&.dig(:value) %>"
+               placeholder="Value"
+               aria-label="Form value">
+      </div>
+      <div class="col-auto">
+        <select class="form-select" name="description[form][][type]" aria-label="Form type">
+          <option value="">-- type --</option>
+          <option value="resource type"      <%= 'selected' if form&.dig(:type) == 'resource type' %>>Resource type</option>
+          <option value="genre"              <%= 'selected' if form&.dig(:type) == 'genre' %>>Genre</option>
+          <option value="form"               <%= 'selected' if form&.dig(:type) == 'form' %>>Form</option>
+          <option value="extent"             <%= 'selected' if form&.dig(:type) == 'extent' %>>Extent</option>
+          <option value="carrier"            <%= 'selected' if form&.dig(:type) == 'carrier' %>>Carrier</option>
+          <option value="media"              <%= 'selected' if form&.dig(:type) == 'media' %>>Media</option>
+          <option value="technique"          <%= 'selected' if form&.dig(:type) == 'technique' %>>Technique</option>
+          <option value="digital origin"     <%= 'selected' if form&.dig(:type) == 'digital origin' %>>Digital origin</option>
+          <option value="data format"        <%= 'selected' if form&.dig(:type) == 'data format' %>>Data format</option>
+        </select>
+      </div>
+      <div class="col-auto">
+        <input type="text"
+               class="form-control"
+               name="description[form][][source_code]"
+               value="<%= form&.dig(:source, :code) %>"
+               placeholder="Source (e.g. lcgft)"
+               aria-label="Form source"
+               style="width: 9rem">
+      </div>
+      <div class="col-auto">
+        <button class="btn btn-sm btn-outline-danger"
+                data-action="description-editor#removeItem"
+                aria-label="Remove form">&times;</button>
+      </div>
+    </div>
+    <%= render 'descriptions/json_toggle', json_data: form || {}, field_name: 'description[form][][_raw_json]' %>
+
+  <% else %>
+    <%# Structured or grouped form — raw JSON escape hatch %>
+    <div class="d-flex gap-2 align-items-start">
+      <div class="flex-grow-1">
+        <p class="small text-info-emphasis bg-info-subtle border border-info-subtle rounded px-2 py-1 mb-1">
+          This form entry has a structured value and must be edited as JSON.
+        </p>
+        <textarea rows="8" class="form-control font-monospace"
+                  name="description[form][][_raw_json]"
+                  aria-label="Form JSON"
+                  data-controller="json-formatter"
+                  data-action="blur->json-formatter#format"><%= JSON.pretty_generate(form) %></textarea>
+      </div>
+      <button class="btn btn-sm btn-outline-danger mt-4 flex-shrink-0"
+              data-action="description-editor#removeItem"
+              aria-label="Remove form">&times;</button>
+    </div>
+  <% end %>
+</div>

--- a/app/views/descriptions/_json_toggle.html.erb
+++ b/app/views/descriptions/_json_toggle.html.erb
@@ -1,0 +1,17 @@
+<% collapse_id = "json-#{json_data.object_id}" %>
+<div class="mt-2">
+  <a class="btn btn-light border opacity-50" style="font-size: 0.7rem; padding: 0.1rem 0.4rem;"
+     data-bs-toggle="collapse"
+     href="#<%= collapse_id %>"
+     aria-expanded="false"
+     aria-controls="<%= collapse_id %>">{ } JSON</a>
+  <div class="collapse" id="<%= collapse_id %>">
+    <textarea name="<%= field_name %>"
+              class="form-control font-monospace mt-1"
+              rows="8"
+              disabled
+              data-controller="json-formatter"
+              data-action="blur->json-formatter#format"
+              aria-label="JSON editor"><%= JSON.pretty_generate(json_data) %></textarea>
+  </div>
+</div>

--- a/app/views/descriptions/_language_fields.html.erb
+++ b/app/views/descriptions/_language_fields.html.erb
@@ -1,0 +1,27 @@
+<div class="mb-2" data-item data-field-type="language" data-controller="description-field">
+  <div class="row g-2 align-items-center">
+    <div class="col-auto">
+      <input type="text"
+             class="form-control"
+             name="description[language][][code]"
+             value="<%= language&.code %>"
+             placeholder="Code (e.g. eng)"
+             aria-label="Language code"
+             style="width: 10rem">
+    </div>
+    <div class="col">
+      <input type="text"
+             class="form-control"
+             name="description[language][][value]"
+             value="<%= language&.value %>"
+             placeholder="Label (e.g. English)"
+             aria-label="Language label">
+    </div>
+    <div class="col-auto">
+      <button class="btn btn-sm btn-outline-danger"
+              data-action="description-editor#removeItem"
+              aria-label="Remove language">&times;</button>
+    </div>
+  </div>
+  <%= render 'descriptions/json_toggle', json_data: language.to_h, field_name: 'description[language][][_raw_json]' %>
+</div>

--- a/app/views/descriptions/_note_fields.html.erb
+++ b/app/views/descriptions/_note_fields.html.erb
@@ -1,0 +1,23 @@
+<div class="mb-3 border rounded p-2" data-item data-field-type="note" data-controller="description-field">
+  <div class="mb-2">
+    <select class="form-select" name="description[note][][type]" aria-label="Note type">
+      <option value="" <%= 'selected' if note&.type.blank? %>>General note</option>
+      <option value="abstract" <%= 'selected' if note&.type == 'abstract' %>>Abstract</option>
+      <option value="statement of responsibility" <%= 'selected' if note&.type == 'statement of responsibility' %>>Statement of responsibility</option>
+      <option value="preferred citation" <%= 'selected' if note&.type == 'preferred citation' %>>Preferred citation</option>
+      <option value="table of contents" <%= 'selected' if note&.type == 'table of contents' %>>Table of contents</option>
+      <option value="biographical/historical" <%= 'selected' if note&.type == 'biographical/historical' %>>Biographical/historical</option>
+    </select>
+  </div>
+  <div class="d-flex gap-2 align-items-start">
+    <textarea class="form-control"
+              name="description[note][][value]"
+              rows="3"
+              placeholder="Note text"
+              aria-label="Note value"><%= note&.value %></textarea>
+    <button class="btn btn-sm btn-outline-danger flex-shrink-0"
+            data-action="description-editor#removeItem"
+            aria-label="Remove note">&times;</button>
+  </div>
+  <%= render 'descriptions/json_toggle', json_data: note.to_h, field_name: 'description[note][][_raw_json]' %>
+</div>

--- a/app/views/descriptions/_physical_location_fields.html.erb
+++ b/app/views/descriptions/_physical_location_fields.html.erb
@@ -1,0 +1,28 @@
+<div class="border rounded p-2 mb-2" data-item>
+  <div class="row g-2 align-items-center">
+    <div class="col">
+      <input type="text"
+             class="form-control"
+             name="description[access][physical_location][][value]"
+             value="<%= physical_location&.dig(:value) %>"
+             placeholder="Location value"
+             aria-label="Physical location value">
+    </div>
+    <div class="col-auto">
+      <select class="form-select"
+              name="description[access][physical_location][][type]"
+              aria-label="Physical location type">
+        <option value="shelf locator"  <%= 'selected' if physical_location&.dig(:type) == 'shelf locator' %>>Shelf locator</option>
+        <option value="location"       <%= 'selected' if physical_location&.dig(:type) == 'location' %>>Location</option>
+        <option value="repository"     <%= 'selected' if physical_location&.dig(:type) == 'repository' %>>Repository</option>
+        <option value="discovery"      <%= 'selected' if physical_location&.dig(:type) == 'discovery' %>>Discovery</option>
+        <option value="series"         <%= 'selected' if physical_location&.dig(:type) == 'series' %>>Series</option>
+      </select>
+    </div>
+    <div class="col-auto">
+      <button class="btn btn-sm btn-outline-danger"
+              data-action="description-editor#removeItem"
+              aria-label="Remove physical location">&times;</button>
+    </div>
+  </div>
+</div>

--- a/app/views/descriptions/_related_resource_fields.html.erb
+++ b/app/views/descriptions/_related_resource_fields.html.erb
@@ -1,0 +1,92 @@
+<%
+  if related_resource.nil?
+    curated = true
+    rr_type = title_val = url_val = nil
+  else
+    simple_title = related_resource.dig(:title, 0, :value).present? &&
+                   related_resource.dig(:title, 0, :structuredValue).blank?
+    has_complex  = related_resource[:contributor].present? ||
+                   related_resource[:event].present? ||
+                   related_resource[:subject].present?
+    curated   = simple_title || (!has_complex && related_resource[:title].blank?)
+    rr_type   = related_resource[:type]
+    title_val = related_resource.dig(:title, 0, :value)
+    url_val   = related_resource.dig(:access, :url, 0, :value)
+  end
+%>
+
+<div class="border rounded p-2 mb-2" data-item data-field-type="related_resource" data-controller="description-field">
+  <% if curated %>
+    <div class="row g-2 mb-2">
+      <div class="col">
+        <input type="text"
+               class="form-control"
+               name="description[related_resource][][title_value]"
+               value="<%= title_val %>"
+               placeholder="Title"
+               aria-label="Related resource title">
+      </div>
+      <div class="col-auto">
+        <select class="form-select"
+                name="description[related_resource][][type]"
+                aria-label="Relationship type">
+          <option value="">-- relationship --</option>
+          <option value="described by"   <%= 'selected' if rr_type == 'described by' %>>Described by</option>
+          <option value="describes"      <%= 'selected' if rr_type == 'describes' %>>Describes</option>
+          <option value="has part"       <%= 'selected' if rr_type == 'has part' %>>Has part</option>
+          <option value="has version"    <%= 'selected' if rr_type == 'has version' %>>Has version</option>
+          <option value="host"           <%= 'selected' if rr_type == 'host' %>>Host</option>
+          <option value="in series"      <%= 'selected' if rr_type == 'in series' %>>In series</option>
+          <option value="part of"        <%= 'selected' if rr_type == 'part of' %>>Part of</option>
+          <option value="referenced by"  <%= 'selected' if rr_type == 'referenced by' %>>Referenced by</option>
+          <option value="references"     <%= 'selected' if rr_type == 'references' %>>References</option>
+          <option value="related to"     <%= 'selected' if rr_type == 'related to' %>>Related to</option>
+          <option value="supplement to"  <%= 'selected' if rr_type == 'supplement to' %>>Supplement to</option>
+          <option value="supplemented by" <%= 'selected' if rr_type == 'supplemented by' %>>Supplemented by</option>
+          <option value="version of record" <%= 'selected' if rr_type == 'version of record' %>>Version of record</option>
+          <option value="other relation type" <%= 'selected' if rr_type == 'other relation type' %>>Other</option>
+        </select>
+      </div>
+      <div class="col-auto">
+        <button class="btn btn-sm btn-outline-danger"
+                data-action="description-editor#removeItem"
+                aria-label="Remove related resource">&times;</button>
+      </div>
+    </div>
+    <div class="row g-2">
+      <div class="col">
+        <input type="text"
+               class="form-control"
+               name="description[related_resource][][url]"
+               value="<%= url_val %>"
+               placeholder="URL (optional)"
+               aria-label="Related resource URL">
+      </div>
+    </div>
+    <%= render 'descriptions/json_toggle', json_data: related_resource || {}, field_name: 'description[related_resource][][_raw_json]' %>
+
+  <% else %>
+    <%# Complex related resource — raw JSON escape hatch %>
+    <%
+      reasons = []
+      reasons << 'a structured title' unless simple_title
+      reasons << 'contributors, events, or subjects' if has_complex
+      reasons = ['a complex structure'] if reasons.empty?
+    %>
+    <div class="d-flex gap-2 align-items-start">
+      <div class="flex-grow-1">
+        <p class="small text-info-emphasis bg-info-subtle border border-info-subtle rounded px-2 py-1 mb-1">
+          This related resource contains <%= reasons.to_sentence %> and must be edited as JSON.
+        </p>
+        <textarea rows="8" class="form-control font-monospace"
+                  name="description[related_resource][][_raw_json]"
+                  aria-label="Related resource JSON"
+                  data-controller="json-formatter"
+                  data-action="blur->json-formatter#format"><%= JSON.pretty_generate(related_resource) %></textarea>
+      </div>
+      <button class="btn btn-sm btn-outline-danger mt-4 flex-shrink-0"
+              data-action="description-editor#removeItem"
+              aria-label="Remove related resource">&times;</button>
+    </div>
+  <% end %>
+</div>

--- a/app/views/descriptions/_subject_fields.html.erb
+++ b/app/views/descriptions/_subject_fields.html.erb
@@ -1,0 +1,115 @@
+<%
+  if subject.nil?
+    curated_simple = true
+    curated_struct = false
+    struct_parts   = []
+  elsif subject.dig(:value).present?
+    curated_simple = true
+    curated_struct = false
+    struct_parts   = []
+  elsif subject.dig(:structuredValue).present? &&
+        subject[:structuredValue].none? { |sv| sv.dig(:structuredValue).present? }
+    curated_simple = false
+    curated_struct = true
+    struct_parts   = subject[:structuredValue]
+  else
+    curated_simple = false
+    curated_struct = false
+    struct_parts   = []
+  end
+%>
+
+<div class="border rounded p-2 mb-2" data-item data-field-type="subject" data-controller="description-field">
+  <% if curated_simple %>
+    <div class="row g-2 align-items-center">
+      <div class="col">
+        <input type="text"
+               class="form-control"
+               name="description[subject][][value]"
+               value="<%= subject&.dig(:value) %>"
+               placeholder="Subject"
+               aria-label="Subject value">
+      </div>
+      <div class="col-auto">
+        <select class="form-select" name="description[subject][][type]" aria-label="Subject type">
+          <option value="topic"           <%= 'selected' if subject&.dig(:type) == 'topic' %>>Topic</option>
+          <option value="place"           <%= 'selected' if subject&.dig(:type) == 'place' %>>Place</option>
+          <option value="temporal"        <%= 'selected' if subject&.dig(:type) == 'temporal' %>>Temporal</option>
+          <option value="person"          <%= 'selected' if subject&.dig(:type) == 'person' %>>Person</option>
+          <option value="organization"    <%= 'selected' if subject&.dig(:type) == 'organization' %>>Organization</option>
+          <option value="genre"           <%= 'selected' if subject&.dig(:type) == 'genre' %>>Genre</option>
+          <option value="classification"  <%= 'selected' if subject&.dig(:type) == 'classification' %>>Classification</option>
+          <option value="map coordinates" <%= 'selected' if subject&.dig(:type) == 'map coordinates' %>>Map coordinates</option>
+        </select>
+      </div>
+      <div class="col-auto">
+        <input type="text"
+               class="form-control"
+               name="description[subject][][source_code]"
+               value="<%= subject&.dig(:source, :code) %>"
+               placeholder="Source (e.g. lcsh)"
+               aria-label="Subject source"
+               style="width: 8rem">
+      </div>
+      <div class="col-auto">
+        <button class="btn btn-sm btn-outline-danger"
+                data-action="description-editor#removeItem"
+                aria-label="Remove subject">&times;</button>
+      </div>
+    <%= render 'descriptions/json_toggle', json_data: subject || {}, field_name: 'description[subject][][_raw_json]' %>
+    </div>
+
+  <% elsif curated_struct %>
+    <%# Flat structuredValue subject (e.g. LCSH compound heading) %>
+    <input type="hidden" name="description[subject][][_struct_original]" value="<%= subject.to_json %>">
+    <% struct_parts.each do |part| %>
+      <div class="row g-2 align-items-center mb-1">
+        <div class="col">
+          <input type="text"
+                 class="form-control"
+                 name="description[subject][][struct_parts][][value]"
+                 value="<%= part[:value] %>"
+                 placeholder="Subject part"
+                 aria-label="Subject part value">
+        </div>
+        <div class="col-auto">
+          <select class="form-select"
+                  name="description[subject][][struct_parts][][type]"
+                  aria-label="Subject part type">
+            <option value="">-- type --</option>
+            <option value="topic"           <%= 'selected' if part[:type] == 'topic' %>>Topic</option>
+            <option value="place"           <%= 'selected' if part[:type] == 'place' %>>Place</option>
+            <option value="temporal"        <%= 'selected' if part[:type] == 'temporal' %>>Temporal</option>
+            <option value="person"          <%= 'selected' if part[:type] == 'person' %>>Person</option>
+            <option value="organization"    <%= 'selected' if part[:type] == 'organization' %>>Organization</option>
+            <option value="genre"           <%= 'selected' if part[:type] == 'genre' %>>Genre</option>
+          </select>
+        </div>
+      </div>
+    <% end %>
+    <div class="text-end">
+      <button class="btn btn-sm btn-outline-danger"
+              data-action="description-editor#removeItem"
+              aria-label="Remove subject">&times;</button>
+    </div>
+    <%= render 'descriptions/json_toggle', json_data: subject, field_name: 'description[subject][][_raw_json]' %>
+
+  <% else %>
+    <%# Deeply nested or code-only subject — raw JSON escape hatch %>
+    <div class="d-flex gap-2 align-items-start">
+      <div class="flex-grow-1">
+        <p class="small text-info-emphasis bg-info-subtle border border-info-subtle rounded px-2 py-1 mb-1">
+          This subject has a complex or code-only structure and must be edited as JSON.
+        </p>
+        <textarea rows="8" class="form-control font-monospace"
+                  name="description[subject][][_raw_json]"
+                  aria-label="Subject JSON"
+                  data-controller="json-formatter"
+                  data-action="blur->json-formatter#format"><%= JSON.pretty_generate(subject) %></textarea>
+      </div>
+      <button class="btn btn-sm btn-outline-danger mt-4 flex-shrink-0"
+              data-action="description-editor#removeItem"
+              aria-label="Remove subject">&times;</button>
+    </div>
+  <% end %>
+</div>

--- a/app/views/descriptions/_subject_fields.html.erb
+++ b/app/views/descriptions/_subject_fields.html.erb
@@ -61,7 +61,7 @@
 
   <% elsif curated_struct %>
     <%# Flat structuredValue subject (e.g. LCSH compound heading) %>
-    <input type="hidden" name="description[subject][][_struct_original]" value="<%= subject.to_json %>">
+    <input type="hidden" name="description[subject][][_struct_original]" value="<%= subject.to_h.to_json %>">
     <% struct_parts.each do |part| %>
       <div class="row g-2 align-items-center mb-1">
         <div class="col">

--- a/app/views/descriptions/_subject_fields.html.erb
+++ b/app/views/descriptions/_subject_fields.html.erb
@@ -34,7 +34,7 @@
         <select class="form-select" name="description[subject][][type]" aria-label="Subject type">
           <option value="topic"           <%= 'selected' if subject&.dig(:type) == 'topic' %>>Topic</option>
           <option value="place"           <%= 'selected' if subject&.dig(:type) == 'place' %>>Place</option>
-          <option value="temporal"        <%= 'selected' if subject&.dig(:type) == 'temporal' %>>Temporal</option>
+          <option value="time"            <%= 'selected' if subject&.dig(:type) == 'time' %>>Temporal</option>
           <option value="person"          <%= 'selected' if subject&.dig(:type) == 'person' %>>Person</option>
           <option value="organization"    <%= 'selected' if subject&.dig(:type) == 'organization' %>>Organization</option>
           <option value="genre"           <%= 'selected' if subject&.dig(:type) == 'genre' %>>Genre</option>
@@ -79,7 +79,7 @@
             <option value="">-- type --</option>
             <option value="topic"           <%= 'selected' if part[:type] == 'topic' %>>Topic</option>
             <option value="place"           <%= 'selected' if part[:type] == 'place' %>>Place</option>
-            <option value="temporal"        <%= 'selected' if part[:type] == 'temporal' %>>Temporal</option>
+            <option value="time"            <%= 'selected' if part[:type] == 'time' %>>Temporal</option>
             <option value="person"          <%= 'selected' if part[:type] == 'person' %>>Person</option>
             <option value="organization"    <%= 'selected' if part[:type] == 'organization' %>>Organization</option>
             <option value="genre"           <%= 'selected' if part[:type] == 'genre' %>>Genre</option>

--- a/app/views/descriptions/_title_fields.html.erb
+++ b/app/views/descriptions/_title_fields.html.erb
@@ -1,0 +1,116 @@
+<%
+  if title.nil?
+    curated_simple = true
+    curated_struct = false
+    title_type = nil
+  elsif title.structuredValue.present? && title.structuredValue.none? { |sv| sv.structuredValue.present? }
+    curated_simple = false
+    curated_struct = true
+    title_type     = title.type
+  elsif title.value.present?
+    curated_simple = true
+    curated_struct = false
+    title_type = title.type
+    main_title_val = subtitle_val = part_number_val = part_name_val = nil
+  else
+    curated_simple = false
+    curated_struct = false
+    title_type = nil
+  end
+%>
+
+<div data-item data-field-type="title" data-controller="description-field" class="mb-2">
+  <% if curated_struct %>
+    <%# Preserve full original so status, non-editable attrs survive round-trip %>
+    <input type="hidden" name="description[title][][_original]" value="<%= title.to_h.to_json %>">
+
+    <div class="border rounded p-2 mb-2">
+      <div class="d-flex justify-content-between align-items-center mb-2">
+        <select class="form-select" style="width: auto" name="description[title][][type]" aria-label="Title type">
+          <option value=""            <%= 'selected' if title_type.blank? %>>— title type —</option>
+          <option value="alternative" <%= 'selected' if title_type == 'alternative' %>>Alternative</option>
+          <option value="uniform"     <%= 'selected' if title_type == 'uniform' %>>Uniform</option>
+          <option value="translated"  <%= 'selected' if title_type == 'translated' %>>Translated</option>
+          <option value="abbreviated" <%= 'selected' if title_type == 'abbreviated' %>>Abbreviated</option>
+          <option value="parallel"    <%= 'selected' if title_type == 'parallel' %>>Parallel</option>
+          <option value="supplied"    <%= 'selected' if title_type == 'supplied' %>>Supplied</option>
+        </select>
+        <button class="btn btn-sm btn-outline-danger"
+                data-action="description-editor#removeItem"
+                aria-label="Remove title">&times;</button>
+      </div>
+      <% title.structuredValue.each do |part| %>
+        <div class="row g-2 mb-1 align-items-center">
+          <div class="col">
+            <input type="text"
+                   class="form-control"
+                   name="description[title][][struct_parts][][value]"
+                   value="<%= part.value %>"
+                   placeholder="Value"
+                   aria-label="Title part value">
+          </div>
+          <div class="col-auto">
+            <select class="form-select"
+                    name="description[title][][struct_parts][][type]"
+                    aria-label="Title part type">
+              <option value="">-- type --</option>
+              <option value="main title"          <%= 'selected' if part.type == 'main title' %>>Main title</option>
+              <option value="subtitle"            <%= 'selected' if part.type == 'subtitle' %>>Subtitle</option>
+              <option value="part number"         <%= 'selected' if part.type == 'part number' %>>Part number</option>
+              <option value="part name"           <%= 'selected' if part.type == 'part name' %>>Part name</option>
+              <option value="nonsorting characters" <%= 'selected' if part.type == 'nonsorting characters' %>>Nonsorting characters</option>
+            </select>
+          </div>
+        </div>
+      <% end %>
+      <%= render 'descriptions/json_toggle', json_data: title.to_h, field_name: 'description[title][][_raw_json]' %>
+    </div>
+
+  <% elsif curated_simple %>
+    <div class="row g-2 mb-2 align-items-center">
+      <div class="col">
+        <input type="text"
+               class="form-control"
+               name="description[title][][value]"
+               value="<%= title&.value %>"
+               placeholder="Title"
+               aria-label="Title value">
+      </div>
+      <div class="col-auto">
+        <select class="form-select" name="description[title][][type]" aria-label="Title type">
+          <option value=""          <%= 'selected' if title_type.blank? %>>Main title</option>
+          <option value="alternative" <%= 'selected' if title_type == 'alternative' %>>Alternative</option>
+          <option value="uniform"     <%= 'selected' if title_type == 'uniform' %>>Uniform</option>
+          <option value="translated"  <%= 'selected' if title_type == 'translated' %>>Translated</option>
+          <option value="abbreviated" <%= 'selected' if title_type == 'abbreviated' %>>Abbreviated</option>
+          <option value="parallel"    <%= 'selected' if title_type == 'parallel' %>>Parallel</option>
+          <option value="supplied"    <%= 'selected' if title_type == 'supplied' %>>Supplied</option>
+        </select>
+      </div>
+      <div class="col-auto">
+        <button class="btn btn-sm btn-outline-danger"
+                data-action="description-editor#removeItem"
+                aria-label="Remove title">&times;</button>
+      </div>
+    </div>
+    <%= render 'descriptions/json_toggle', json_data: title.to_h, field_name: 'description[title][][_raw_json]' %>
+
+  <% else %>
+    <%# Deeply nested structuredValue — raw JSON escape hatch %>
+    <div class="d-flex gap-2 align-items-start mb-2">
+      <div class="flex-grow-1">
+        <p class="small text-info-emphasis bg-info-subtle border border-info-subtle rounded px-2 py-1 mb-1">
+          This title contains nested structured values and must be edited as JSON.
+        </p>
+        <textarea rows="8" class="form-control font-monospace"
+                  name="description[title][][_raw_json]"
+                  aria-label="Title JSON"
+                  data-controller="json-formatter"
+                  data-action="blur->json-formatter#format"><%= JSON.pretty_generate(title.to_h) %></textarea>
+      </div>
+      <button class="btn btn-sm btn-outline-danger mt-4 flex-shrink-0"
+              data-action="description-editor#removeItem"
+              aria-label="Remove title">&times;</button>
+    </div>
+  <% end %>
+</div>

--- a/app/views/descriptions/edit.html.erb
+++ b/app/views/descriptions/edit.html.erb
@@ -1,0 +1,380 @@
+<%= turbo_frame_tag(@cocina_object.externalIdentifier, 'description') do %>
+<div class="mt-3"
+     data-controller="description-editor"
+     data-render-field-url="<%= render_field_object_description_path(object_druid: @cocina_object.externalIdentifier) %>"
+     data-field-json-url="<%= field_json_object_description_path(object_druid: @cocina_object.externalIdentifier) %>">
+  <% if flash[:warning] %>
+    <div class="alert alert-warning" role="alert"><%= flash[:warning] %></div>
+  <% end %>
+
+  <%= form_with url: object_description_path(object_druid: @cocina_object.externalIdentifier),
+                method: :patch,
+                class: 'needs-validation',
+                data: { turbo_frame: '_top' } do %>
+
+    <%# TITLES %>
+    <div class="card mb-3">
+      <div class="card-header fw-semibold">Titles</div>
+      <div class="card-body">
+        <div id="title-list">
+          <% (@cocina_object.description.title || []).each do |title| %>
+            <%= render 'title_fields', title: title %>
+          <% end %>
+        </div>
+
+        <template id="title-template">
+          <%= render 'title_fields', title: nil %>
+        </template>
+
+        <template id="structured-title-template">
+          <div data-item data-field-type="title" data-controller="description-field">
+            <div class="border rounded p-2 mb-2">
+              <div class="d-flex justify-content-between align-items-center mb-2">
+                <select class="form-select" style="width: auto" name="description[title][][type]" aria-label="Title type">
+                  <option value="">— title type —</option>
+                  <option value="alternative">Alternative</option>
+                  <option value="uniform">Uniform</option>
+                  <option value="translated">Translated</option>
+                  <option value="abbreviated">Abbreviated</option>
+                  <option value="parallel">Parallel</option>
+                  <option value="supplied">Supplied</option>
+                </select>
+                <button class="btn btn-sm btn-outline-danger" data-action="description-editor#removeItem" aria-label="Remove title">&times;</button>
+              </div>
+              <div class="row g-2 mb-1 align-items-center">
+                <div class="col">
+                  <input type="text" class="form-control" name="description[title][][struct_parts][][value]" placeholder="Value" aria-label="Title part value">
+                </div>
+                <div class="col-auto">
+                  <select class="form-select" name="description[title][][struct_parts][][type]" aria-label="Title part type">
+                    <option value="">— type —</option>
+                    <option value="main title">Main title</option>
+                    <option value="subtitle">Subtitle</option>
+                    <option value="part number">Part number</option>
+                    <option value="part name">Part name</option>
+                    <option value="nonsorting characters">Nonsorting characters</option>
+                  </select>
+                </div>
+              </div>
+              <div class="row g-2 mb-1 align-items-center">
+                <div class="col">
+                  <input type="text" class="form-control" name="description[title][][struct_parts][][value]" placeholder="Value" aria-label="Title part value">
+                </div>
+                <div class="col-auto">
+                  <select class="form-select" name="description[title][][struct_parts][][type]" aria-label="Title part type">
+                    <option value="">— type —</option>
+                    <option value="main title">Main title</option>
+                    <option value="subtitle">Subtitle</option>
+                    <option value="part number">Part number</option>
+                    <option value="part name">Part name</option>
+                    <option value="nonsorting characters">Nonsorting characters</option>
+                  </select>
+                </div>
+              </div>
+            </div>
+          </div>
+        </template>
+
+        <div class="d-flex gap-2 mt-2">
+          <button class="btn btn-sm btn-outline-secondary"
+                  data-action="description-editor#addItem"
+                  data-list-id="title-list"
+                  data-template-id="title-template">+ Add title</button>
+          <button class="btn btn-sm btn-outline-secondary"
+                  data-action="description-editor#addItem"
+                  data-list-id="title-list"
+                  data-template-id="structured-title-template">+ Add structured title</button>
+        </div>
+      </div>
+    </div>
+
+    <%# NOTES %>
+    <div class="card mb-3">
+      <div class="card-header fw-semibold">Notes</div>
+      <div class="card-body">
+        <div id="note-list">
+          <% (@cocina_object.description.note || []).each do |note| %>
+            <%= render 'note_fields', note: note %>
+          <% end %>
+        </div>
+
+        <template id="note-template">
+          <%= render 'note_fields', note: nil %>
+        </template>
+
+        <button class="btn btn-sm btn-outline-secondary mt-2"
+                data-action="description-editor#addItem"
+                data-list-id="note-list"
+                data-template-id="note-template">+ Add note</button>
+      </div>
+    </div>
+
+    <%# CONTRIBUTORS %>
+    <div class="card mb-3">
+      <div class="card-header fw-semibold">Contributors</div>
+      <div class="card-body">
+        <div id="contributor-list">
+          <% (@cocina_object.description.to_h[:contributor] || []).each do |contributor| %>
+            <%= render 'contributor_fields', contributor: contributor %>
+          <% end %>
+        </div>
+
+        <template id="contributor-template">
+          <%= render 'contributor_fields', contributor: nil %>
+        </template>
+
+        <button class="btn btn-sm btn-outline-secondary mt-2"
+                data-action="description-editor#addItem"
+                data-list-id="contributor-list"
+                data-template-id="contributor-template">+ Add contributor</button>
+      </div>
+    </div>
+
+    <%# SUBJECTS %>
+    <div class="card mb-3">
+      <div class="card-header fw-semibold">Subjects</div>
+      <div class="card-body">
+        <div id="subject-list">
+          <% (@cocina_object.description.to_h[:subject] || []).each do |subject| %>
+            <%= render 'subject_fields', subject: subject %>
+          <% end %>
+        </div>
+
+        <template id="subject-template">
+          <%= render 'subject_fields', subject: nil %>
+        </template>
+
+        <template id="structured-subject-template">
+          <div class="border rounded p-2 mb-2" data-item data-field-type="subject" data-controller="description-field">
+            <% [nil, nil, nil].each do %>
+              <div class="row g-2 align-items-center mb-1">
+                <div class="col">
+                  <input type="text" class="form-control"
+                         name="description[subject][][struct_parts][][value]"
+                         placeholder="Subject part" aria-label="Subject part value">
+                </div>
+                <div class="col-auto">
+                  <select class="form-select"
+                          name="description[subject][][struct_parts][][type]"
+                          aria-label="Subject part type">
+                    <option value="">— type —</option>
+                    <option value="topic">Topic</option>
+                    <option value="place">Place</option>
+                    <option value="temporal">Temporal</option>
+                    <option value="person">Person</option>
+                    <option value="organization">Organization</option>
+                    <option value="genre">Genre</option>
+                  </select>
+                </div>
+              </div>
+            <% end %>
+            <div class="text-end">
+              <button class="btn btn-sm btn-outline-danger"
+                      data-action="description-editor#removeItem"
+                      aria-label="Remove subject">&times;</button>
+            </div>
+          </div>
+        </template>
+
+        <div class="d-flex gap-2 mt-2">
+          <button class="btn btn-sm btn-outline-secondary"
+                  data-action="description-editor#addItem"
+                  data-list-id="subject-list"
+                  data-template-id="subject-template">+ Add subject</button>
+          <button class="btn btn-sm btn-outline-secondary"
+                  data-action="description-editor#addItem"
+                  data-list-id="subject-list"
+                  data-template-id="structured-subject-template">+ Add structured subject</button>
+        </div>
+      </div>
+    </div>
+
+    <%# LANGUAGE %>
+    <div class="card mb-3">
+      <div class="card-header fw-semibold">Language</div>
+      <div class="card-body">
+        <div id="language-list">
+          <% (@cocina_object.description.language || []).each do |language| %>
+            <%= render 'language_fields', language: language %>
+          <% end %>
+        </div>
+
+        <template id="language-template">
+          <%= render 'language_fields', language: nil %>
+        </template>
+
+        <button class="btn btn-sm btn-outline-secondary mt-2"
+                data-action="description-editor#addItem"
+                data-list-id="language-list"
+                data-template-id="language-template">+ Add language</button>
+      </div>
+    </div>
+
+    <%# FORM %>
+    <div class="card mb-3">
+      <div class="card-header fw-semibold">Form</div>
+      <div class="card-body">
+        <div id="form-list">
+          <% (@cocina_object.description.to_h[:form] || []).each do |form| %>
+            <%= render 'form_fields', form: form %>
+          <% end %>
+        </div>
+
+        <template id="form-template">
+          <%= render 'form_fields', form: nil %>
+        </template>
+
+        <button class="btn btn-sm btn-outline-secondary mt-2"
+                data-action="description-editor#addItem"
+                data-list-id="form-list"
+                data-template-id="form-template">+ Add form</button>
+      </div>
+    </div>
+
+    <%# EVENTS %>
+    <div class="card mb-3">
+      <div class="card-header fw-semibold">Events</div>
+      <div class="card-body">
+        <div id="event-list">
+          <% (@cocina_object.description.to_h[:event] || []).each do |event| %>
+            <%= render 'event_fields', event: event %>
+          <% end %>
+        </div>
+
+        <template id="event-template">
+          <%= render 'event_fields', event: nil %>
+        </template>
+
+        <template id="date-range-event-template">
+          <div class="border rounded p-2 mb-2" data-item data-field-type="event" data-controller="description-field">
+            <input type="hidden" name="description[event][][_original]" value="">
+            <div class="row g-2 mb-2 align-items-center">
+              <div class="col-auto">
+                <select class="form-select" name="description[event][][type]" aria-label="Event type">
+                  <option value="">-- type --</option>
+                  <option value="acquisition">Acquisition</option>
+                  <option value="broadcast">Broadcast</option>
+                  <option value="capture">Capture</option>
+                  <option value="copyright">Copyright</option>
+                  <option value="creation">Creation</option>
+                  <option value="degree conferral">Degree conferral</option>
+                  <option value="deposit">Deposit</option>
+                  <option value="distribution">Distribution</option>
+                  <option value="manufacture">Manufacture</option>
+                  <option value="performance">Performance</option>
+                  <option value="production">Production</option>
+                  <option value="publication">Publication</option>
+                </select>
+              </div>
+              <div class="col">
+                <input type="text" class="form-control"
+                       name="description[event][][date_start_value]"
+                       placeholder="Start date" aria-label="Start date">
+              </div>
+              <div class="col">
+                <input type="text" class="form-control"
+                       name="description[event][][date_end_value]"
+                       placeholder="End date" aria-label="End date">
+              </div>
+              <div class="col-auto">
+                <button class="btn btn-sm btn-outline-danger"
+                        data-action="description-editor#removeItem"
+                        aria-label="Remove event">&times;</button>
+              </div>
+            </div>
+            <div class="row g-2 align-items-center">
+              <div class="col">
+                <input type="text" class="form-control"
+                       name="description[event][][publisher_value]"
+                       placeholder="Publisher (optional)" aria-label="Publisher">
+              </div>
+              <div class="col">
+                <input type="text" class="form-control"
+                       name="description[event][][place_value]"
+                       placeholder="Place (e.g. New York)" aria-label="Event place">
+              </div>
+            </div>
+          </div>
+        </template>
+
+        <div class="d-flex gap-2 mt-2">
+          <button class="btn btn-sm btn-outline-secondary"
+                  data-action="description-editor#addItem"
+                  data-list-id="event-list"
+                  data-template-id="event-template">+ Add event</button>
+          <button class="btn btn-sm btn-outline-secondary"
+                  data-action="description-editor#addItem"
+                  data-list-id="event-list"
+                  data-template-id="date-range-event-template">+ Add event with date range</button>
+        </div>
+      </div>
+    </div>
+
+    <%# PHYSICAL ACCESS %>
+    <div class="card mb-3">
+      <div class="card-header fw-semibold">Physical Access</div>
+      <div class="card-body">
+        <h6 class="text-muted small fw-semibold mb-2">Physical Locations</h6>
+        <div id="physical-location-list">
+          <% (@cocina_object.description.to_h.dig(:access, :physicalLocation) || []).each do |pl| %>
+            <%= render 'physical_location_fields', physical_location: pl %>
+          <% end %>
+        </div>
+
+        <template id="physical-location-template">
+          <%= render 'physical_location_fields', physical_location: nil %>
+        </template>
+
+        <button class="btn btn-sm btn-outline-secondary mt-2"
+                data-action="description-editor#addItem"
+                data-list-id="physical-location-list"
+                data-template-id="physical-location-template">+ Add physical location</button>
+
+        <hr class="my-3">
+
+        <h6 class="text-muted small fw-semibold mb-2">Access Contacts</h6>
+        <div id="access-contact-list">
+          <% (@cocina_object.description.to_h.dig(:access, :accessContact) || []).each do |ac| %>
+            <%= render 'access_contact_fields', access_contact: ac %>
+          <% end %>
+        </div>
+
+        <template id="access-contact-template">
+          <%= render 'access_contact_fields', access_contact: nil %>
+        </template>
+
+        <button class="btn btn-sm btn-outline-secondary mt-2"
+                data-action="description-editor#addItem"
+                data-list-id="access-contact-list"
+                data-template-id="access-contact-template">+ Add access contact</button>
+      </div>
+    </div>
+
+    <%# RELATED RESOURCES %>
+    <div class="card mb-3">
+      <div class="card-header fw-semibold">Related Resources</div>
+      <div class="card-body">
+        <div id="related-resource-list">
+          <% (@cocina_object.description.to_h[:relatedResource] || []).each do |rr| %>
+            <%= render 'related_resource_fields', related_resource: rr %>
+          <% end %>
+        </div>
+
+        <template id="related-resource-template">
+          <%= render 'related_resource_fields', related_resource: nil %>
+        </template>
+
+        <button class="btn btn-sm btn-outline-secondary mt-2"
+                data-action="description-editor#addItem"
+                data-list-id="related-resource-list"
+                data-template-id="related-resource-template">+ Add related resource</button>
+      </div>
+    </div>
+
+    <div class="d-flex gap-2">
+      <%= link_to 'Cancel', object_path(druid: @cocina_object.externalIdentifier), class: 'btn btn-outline-secondary' %>
+      <button type="submit" class="btn btn-primary">Save description</button>
+    </div>
+  <% end %>
+</div>
+<% end %>

--- a/app/views/descriptions/edit.html.erb
+++ b/app/views/descriptions/edit.html.erb
@@ -164,7 +164,7 @@
                     <option value="">— type —</option>
                     <option value="topic">Topic</option>
                     <option value="place">Place</option>
-                    <option value="temporal">Temporal</option>
+                    <option value="time">Temporal</option>
                     <option value="person">Person</option>
                     <option value="organization">Organization</option>
                     <option value="genre">Genre</option>

--- a/app/views/descriptions/edit.html.erb
+++ b/app/views/descriptions/edit.html.erb
@@ -1,3 +1,7 @@
+<%# The .container is ignored when this frame loads inside the object show page (Turbo extracts %>
+<%# only the matching turbo-frame); it supplies the page margin when the form re-renders as a %>
+<%# full page after a save error, since the form breaks out to _top. %>
+<div class="container">
 <%= turbo_frame_tag(@cocina_object.externalIdentifier, 'description') do %>
 <div class="mt-3"
      data-controller="description-editor"
@@ -378,3 +382,4 @@
   <% end %>
 </div>
 <% end %>
+</div>

--- a/app/views/objects/show.html.erb
+++ b/app/views/objects/show.html.erb
@@ -15,7 +15,6 @@
   <% end %>
 
   <%= render SdrViewComponents::Elements::Tabs::TabListComponent.new(classes: 'mb-3', variant: :underline) do |component| %>
-
     <% component.with_tab(id: 'details-tab', pane_id: 'details-pane', label: 'Details', active: true) %>
     <% component.with_tab(id: 'workflows-tab', pane_id: 'workflows-pane', label: 'Workflows') %>
     <% component.with_tab(id: 'versions-tab', pane_id: 'versions-pane', label: 'Versions') %>
@@ -25,6 +24,7 @@
     <% component.with_tab(id: 'cocina-model-tab', pane_id: 'cocina-model-pane', label: 'Cocina Model') %>
     <% component.with_tab(id: 'solr-doc-tab', pane_id: 'solr-doc-pane', label: 'Solr Document') %>
     <% component.with_tab(id: 'purl-preview-tab', pane_id: 'purl-preview-pane', label: 'PURL Description Preview') if @solr_doc.dro? || @solr_doc.collection? %>
+    <% component.with_tab(id: 'description-edit-tab', pane_id: 'description-edit-pane', label: 'Edit description') %>
 
     <%= component.with_pane(id: 'details-pane', tab_id: 'details-tab', active: true) do %>
       <%= turbo_frame_tag(@solr_doc.druid, 'details', src: details_object_path(druid: @druid_token), refresh: 'morph', target: '_top') do %>
@@ -74,6 +74,12 @@
         <%= render SdrViewComponents::Elements::SpinnerComponent.new %>
       <% end %>
     <% end %>
+    <% end %>
+
+    <%= component.with_pane(id: 'description-edit-pane', tab_id: 'description-edit-tab') do %>
+      <%= turbo_frame_tag(@solr_doc.druid, 'description', src: edit_object_description_path(object_druid: @solr_doc.druid)) do %>
+        <%= render SdrViewComponents::Elements::SpinnerComponent.new %>
+      <% end %>
     <% end %>
   <% end %>
 <% end %>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -166,6 +166,10 @@ Rails.application.routes.draw do
       get 'purl_preview', to: 'objects#show_purl_preview'
       get 'solr_doc', to: 'objects#show_solr_doc'
     end
+    resource :description, only: %i[edit update] do
+      post :render_field
+      post :field_json
+    end
   end
 
   namespace :admin do

--- a/spec/requests/descriptions_spec.rb
+++ b/spec/requests/descriptions_spec.rb
@@ -1,0 +1,124 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe 'Editing description' do
+  let(:druid) { 'druid:bc123df4567' }
+  let(:cocina_object) { build(:dro_with_metadata, id: druid) }
+  let(:admin_user) { create(:user, :admin) }
+  let(:non_admin_user) { create(:user) }
+
+  before do
+    allow(Sdr::Repository).to receive(:find).with(druid:).and_return(cocina_object)
+  end
+
+  describe 'GET /objects/:druid/description/edit' do
+    context 'when the user is an admin' do
+      before { sign_in admin_user }
+
+      it 'renders the edit form' do
+        get edit_object_description_path(object_druid: druid)
+
+        expect(response).to have_http_status(:ok)
+      end
+    end
+
+    context 'when the user is not an admin' do
+      before { sign_in non_admin_user }
+
+      it 'redirects with an authorization error' do
+        get edit_object_description_path(object_druid: druid)
+
+        expect(response).to redirect_to(root_path)
+      end
+    end
+  end
+
+  describe 'PATCH /objects/:druid/description' do
+    let(:description_params) do
+      {
+        description: {
+          title: [{ value: 'Updated Title', type: '' }],
+          note: [{ value: 'An abstract.', type: 'abstract' }],
+          language: [{ code: 'eng', value: 'English' }],
+          contributor: [{ name_value: 'Smith, Jane', type: 'person', primary: '1' }],
+          subject: [{ value: 'History', type: 'topic', source_code: 'lcsh' }],
+          form: [{ value: '1 score (77 leaves)', type: 'extent' }],
+          event: [{ type: 'publication', date_value: '1978', place_value: 'New York' }],
+          related_resource: [{ title_value: 'Finding Aid', type: 'described by', url: 'https://example.com/fa' }],
+          access: {
+            physical_location: [{ value: 'PC0139', type: 'shelf locator' }],
+            access_contact: [{ value: 'spec@stanford.edu', type: 'email' }]
+          }
+        }
+      }
+    end
+
+    context 'when the user is an admin' do
+      before do
+        sign_in admin_user
+        allow(Sdr::VersionService).to receive_messages(open?: true, closeable?: true)
+        allow(Sdr::VersionService).to receive(:close)
+        allow(Sdr::Repository).to receive(:update)
+      end
+
+      it 'updates the description and redirects to the object page' do
+        patch object_description_path(object_druid: druid), params: description_params
+
+        expect(Sdr::Repository).to have_received(:update) do |args|
+          updated_description = args[:cocina_object].description
+          expect(updated_description.title.first.value).to eq('Updated Title')
+          expect(updated_description.note.first.value).to eq('An abstract.')
+          expect(updated_description.language.first.code).to eq('eng')
+        end
+        expect(response).to redirect_to(object_path(druid:))
+      end
+
+      it 'closes the version after saving' do
+        patch object_description_path(object_druid: druid), params: description_params
+
+        expect(Sdr::VersionService).to have_received(:close).with(druid:)
+      end
+
+      it 'opens a version when the object version is closed' do
+        allow(Sdr::VersionService).to receive(:open?).and_return(false)
+        allow(Sdr::VersionService).to receive(:open)
+
+        patch object_description_path(object_druid: druid), params: description_params
+
+        expect(Sdr::VersionService).to have_received(:open).with(
+          druid:,
+          description: 'Descriptive metadata edited via web form',
+          opening_user_name: admin_user.sunetid
+        )
+      end
+
+      it 'does not close the version if it is not closeable' do
+        allow(Sdr::VersionService).to receive(:closeable?).and_return(false)
+
+        patch object_description_path(object_druid: druid), params: description_params
+
+        expect(Sdr::VersionService).not_to have_received(:close)
+      end
+
+      it 're-renders the form when validation fails' do
+        allow(CocinaSupport).to receive(:validate).and_return(Dry::Monads::Failure('title is required'))
+
+        patch object_description_path(object_druid: druid), params: description_params
+
+        expect(response).to have_http_status(:unprocessable_content)
+        expect(Sdr::Repository).not_to have_received(:update)
+      end
+    end
+
+    context 'when the user is not an admin' do
+      before { sign_in non_admin_user }
+
+      it 'redirects with an authorization error' do
+        patch object_description_path(object_druid: druid), params: description_params
+
+        expect(response).to redirect_to(root_path)
+      end
+    end
+  end
+end

--- a/spec/requests/descriptions_spec.rb
+++ b/spec/requests/descriptions_spec.rb
@@ -80,17 +80,30 @@ RSpec.describe 'Editing description' do
         expect(Sdr::VersionService).to have_received(:close).with(druid:)
       end
 
-      it 'opens a version when the object version is closed' do
-        allow(Sdr::VersionService).to receive(:open?).and_return(false)
-        allow(Sdr::VersionService).to receive(:open)
+      context 'when the object version is closed' do
+        let(:opened_object) { cocina_object.new(version: cocina_object.version + 1) }
 
-        patch object_description_path(object_druid: druid), params: description_params
+        before do
+          allow(Sdr::VersionService).to receive_messages(open?: false, open: opened_object)
+        end
 
-        expect(Sdr::VersionService).to have_received(:open).with(
-          druid:,
-          description: 'Descriptive metadata edited via web form',
-          opening_user_name: admin_user.sunetid
-        )
+        it 'opens a new version' do
+          patch object_description_path(object_druid: druid), params: description_params
+
+          expect(Sdr::VersionService).to have_received(:open).with(
+            druid:,
+            description: 'Descriptive metadata edited via web form',
+            opening_user_name: admin_user.sunetid
+          )
+        end
+
+        it 'updates the newly opened version rather than the stale one' do
+          patch object_description_path(object_druid: druid), params: description_params
+
+          expect(Sdr::Repository).to have_received(:update) do |args|
+            expect(args[:cocina_object].version).to eq(opened_object.version)
+          end
+        end
       end
 
       it 'does not close the version if it is not closeable' do

--- a/spec/services/description_builder_spec.rb
+++ b/spec/services/description_builder_spec.rb
@@ -1,0 +1,454 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe DescriptionBuilder do
+  subject(:builder) { described_class.new(existing_description: existing) }
+
+  let(:existing) { { title: [{ value: 'Original title' }] } }
+
+  describe '#build' do
+    it 'falls back to existing values when submitted fields are all blank' do
+      result = builder.build({ title: [{ value: '' }] })
+      expect(result[:title]).to eq([{ value: 'Original title' }])
+    end
+
+    it 'preserves existing fields not present in submitted params' do
+      existing[:note] = [{ value: 'Existing note', type: 'abstract' }]
+      result = builder.build({ title: [{ value: 'New title' }] })
+      expect(result[:note]).to eq([{ value: 'Existing note', type: 'abstract' }])
+    end
+
+    it 'removes nil values from the result' do
+      result = builder.build({ title: [{ value: 'A title' }] })
+      expect(result).not_to have_key(:note)
+    end
+  end
+
+  describe 'title building' do
+    context 'with a simple value' do
+      it 'builds a plain title' do
+        result = builder.build({ title: [{ value: 'My Title', type: '' }] })
+        expect(result[:title]).to eq([{ value: 'My Title' }])
+      end
+
+      it 'includes type when present' do
+        result = builder.build({ title: [{ value: 'Alt', type: 'alternative' }] })
+        expect(result[:title].first).to eq({ value: 'Alt', type: 'alternative' })
+      end
+
+      it 'drops entries with blank value' do
+        result = builder.build({ title: [{ value: '' }, { value: 'Real' }] })
+        expect(result[:title]).to eq([{ value: 'Real' }])
+      end
+    end
+
+    context 'with struct_parts' do
+      it 'builds a structuredValue title from parts' do
+        result = builder.build({
+                                 title: [{ struct_parts: [{ value: 'The', type: 'nonsorting characters' },
+                                                          { value: 'Great Gatsby', type: 'main title' }],
+                                           type: '' }]
+                               })
+        expect(result[:title].first[:structuredValue]).to eq([
+                                                               { value: 'The', type: 'nonsorting characters' },
+                                                               { value: 'Great Gatsby', type: 'main title' }
+                                                             ])
+      end
+
+      it 'sets type on the structured title when present' do
+        result = builder.build({
+                                 title: [{ struct_parts: [{ value: 'Uniform', type: 'main title' }], type: 'uniform' }]
+                               })
+        expect(result[:title].first[:type]).to eq('uniform')
+      end
+
+      it 'removes type when blank' do
+        result = builder.build({
+                                 title: [{ struct_parts: [{ value: 'A', type: 'main title' }], type: '' }]
+                               })
+        expect(result[:title].first).not_to have_key(:type)
+      end
+
+      it 'filters out blank parts' do
+        result = builder.build({
+                                 title: [{ struct_parts: [{ value: '', type: 'main title' },
+                                                          { value: 'Real', type: 'main title' }], type: '' }]
+                               })
+        expect(result[:title].first[:structuredValue]).to eq([{ value: 'Real', type: 'main title' }])
+      end
+
+      it 'returns nil (drops the title) when all parts are blank' do
+        result = builder.build({
+                                 title: [{ struct_parts: [{ value: '', type: '' }], type: '' }]
+                               })
+        expect(result[:title]).to eq([{ value: 'Original title' }])
+      end
+
+      it 'merges _original to preserve unexposed fields' do
+        original = { status: 'primary', structuredValue: [] }.to_json
+        result = builder.build({
+                                 title: [{ struct_parts: [{ value: 'Title', type: 'main title' }],
+                                           _original: original, type: '' }]
+                               })
+        expect(result[:title].first[:status]).to eq('primary')
+      end
+    end
+
+    context 'with _raw_json' do
+      it 'parses and uses the raw JSON directly' do
+        raw = { structuredValue: [{ value: 'A', type: 'main title' }] }.to_json
+        result = builder.build({ title: [{ _raw_json: raw }] })
+        expect(result[:title].first[:structuredValue]).to eq([{ value: 'A', type: 'main title' }])
+      end
+
+      it 'drops the title when raw JSON is invalid' do
+        result = builder.build({ title: [{ _raw_json: '{invalid' }] })
+        expect(result[:title]).to eq([{ value: 'Original title' }])
+      end
+    end
+  end
+
+  describe 'note building' do
+    it 'builds a note with value and type' do
+      result = builder.build({ note: [{ value: 'An abstract', type: 'abstract' }] })
+      expect(result[:note]).to eq([{ value: 'An abstract', type: 'abstract' }])
+    end
+
+    it 'drops notes with blank value' do
+      result = builder.build({ note: [{ value: '', type: 'abstract' }] })
+      expect(result[:note]).to be_nil
+    end
+  end
+
+  describe 'language building' do
+    it 'builds a language entry' do
+      result = builder.build({ language: [{ code: 'eng', value: 'English' }] })
+      expect(result[:language].first).to eq({ code: 'eng', value: 'English' })
+    end
+
+    it 'drops entries with blank code' do
+      result = builder.build({ language: [{ code: '', value: 'Unknown' }] })
+      expect(result[:language]).to be_nil
+    end
+  end
+
+  describe 'contributor building' do
+    context 'with a simple name' do
+      it 'builds a contributor with a plain name value' do
+        result = builder.build({
+                                 contributor: [{ name_value: 'Smith, Jane', type: 'person', primary: '0' }]
+                               })
+        expect(result[:contributor].first[:name]).to eq([{ value: 'Smith, Jane' }])
+        expect(result[:contributor].first[:type]).to eq('person')
+      end
+
+      it 'marks the contributor as primary when checked' do
+        result = builder.build({
+                                 contributor: [{ name_value: 'Smith, Jane', type: 'person', primary: '1' }]
+                               })
+        expect(result[:contributor].first[:status]).to eq('primary')
+      end
+
+      it 'removes primary status when unchecked' do
+        original = { name: [{ value: 'Smith, Jane' }], status: 'primary' }.to_json
+        result = builder.build({
+                                 contributor: [{ name_value: 'Smith, Jane', type: 'person', primary: '0',
+                                                 _original: original }]
+                               })
+        expect(result[:contributor].first).not_to have_key(:status)
+      end
+    end
+
+    context 'with life dates' do
+      it 'builds a structuredValue name with life dates' do
+        result = builder.build({
+                                 contributor: [{ name_value: 'Twain, Mark', life_dates: '1835-1910',
+                                                 type: 'person', primary: '0' }]
+                               })
+        name = result[:contributor].first[:name].first
+        expect(name[:structuredValue]).to eq([
+                                               { value: 'Twain, Mark', type: 'name' },
+                                               { value: '1835-1910', type: 'life dates' }
+                                             ])
+      end
+    end
+
+    context 'with a role' do
+      it 'sets the role value' do
+        result = builder.build({
+                                 contributor: [{ name_value: 'Smith, Jane', type: 'person',
+                                                 primary: '0', role_value: 'author' }]
+                               })
+        expect(result[:contributor].first[:role]).to eq([{ value: 'author' }])
+      end
+
+      it 'preserves existing role code/uri from _original' do
+        original = { name: [{ value: 'x' }],
+                     role: [{ value: 'old', code: 'aut', source: { code: 'marcrelator' } }] }.to_json
+        result = builder.build({
+                                 contributor: [{ name_value: 'Smith, Jane', type: 'person',
+                                                 primary: '0', role_value: 'author', _original: original }]
+                               })
+        role = result[:contributor].first[:role].first
+        expect(role[:value]).to eq('author')
+        expect(role[:code]).to eq('aut')
+        expect(role[:source]).to eq({ code: 'marcrelator' })
+      end
+    end
+
+    context 'with _raw_json' do
+      it 'uses raw JSON directly' do
+        raw = { name: [{ value: 'Complex Corp' }], type: 'organization' }.to_json
+        result = builder.build({ contributor: [{ _raw_json: raw }] })
+        expect(result[:contributor].first[:type]).to eq('organization')
+      end
+    end
+
+    it 'drops contributors with blank name' do
+      result = builder.build({ contributor: [{ name_value: '', type: 'person' }] })
+      expect(result[:contributor]).to be_nil
+    end
+  end
+
+  describe 'subject building' do
+    context 'with a simple value' do
+      it 'builds a subject with type and source' do
+        result = builder.build({
+                                 subject: [{ value: 'History', type: 'topic', source_code: 'lcsh' }]
+                               })
+        expect(result[:subject].first).to eq({
+                                               value: 'History', type: 'topic', source: { code: 'lcsh' }
+                                             })
+      end
+
+      it 'drops subjects with blank value' do
+        result = builder.build({ subject: [{ value: '', type: 'topic' }] })
+        expect(result[:subject]).to be_nil
+      end
+    end
+
+    context 'with struct_parts' do
+      it 'builds a compound subject heading' do
+        result = builder.build({
+                                 subject: [{ struct_parts: [{ value: 'Music', type: 'topic' },
+                                                            { value: 'France', type: 'place' }] }]
+                               })
+        expect(result[:subject].first[:structuredValue]).to eq([
+                                                                 { value: 'Music', type: 'topic' },
+                                                                 { value: 'France', type: 'place' }
+                                                               ])
+      end
+
+      it 'merges _struct_original to preserve source and other fields' do
+        original = { source: { code: 'lcsh' }, structuredValue: [] }.to_json
+        result = builder.build({
+                                 subject: [{ struct_parts: [{ value: 'Music', type: 'topic' }],
+                                             _struct_original: original }]
+                               })
+        expect(result[:subject].first[:source]).to eq({ code: 'lcsh' })
+      end
+    end
+
+    context 'with _raw_json' do
+      it 'uses raw JSON directly' do
+        raw = { value: 'Coordinates', type: 'map coordinates' }.to_json
+        result = builder.build({ subject: [{ _raw_json: raw }] })
+        expect(result[:subject].first[:type]).to eq('map coordinates')
+      end
+    end
+  end
+
+  describe 'form building' do
+    it 'builds a form entry with type and source' do
+      result = builder.build({
+                               form: [{ value: 'text', type: 'resource type', source_code: 'aat' }]
+                             })
+      expect(result[:form].first).to eq({ value: 'text', type: 'resource type', source: { code: 'aat' } })
+    end
+
+    it 'drops form entries with blank value' do
+      result = builder.build({ form: [{ value: '', type: 'resource type' }] })
+      expect(result[:form]).to be_nil
+    end
+
+    it 'uses raw JSON when present' do
+      raw = { value: 'score', type: 'notated music' }.to_json
+      result = builder.build({ form: [{ _raw_json: raw }] })
+      expect(result[:form].first).to eq({ value: 'score', type: 'notated music' })
+    end
+  end
+
+  describe 'event building' do
+    context 'with a single date' do
+      it 'builds an event with type and date' do
+        result = builder.build({
+                                 event: [{ type: 'publication', date_value: '1978', _original: '{}' }]
+                               })
+        expect(result[:event].first[:type]).to eq('publication')
+        expect(result[:event].first[:date]).to eq([{ value: '1978' }])
+      end
+
+      it 'preserves date encoding from _original' do
+        original = { date: [{ value: '1978', encoding: { code: 'marc' } }] }.to_json
+        result = builder.build({
+                                 event: [{ type: 'publication', date_value: '1979', _original: original }]
+                               })
+        expect(result[:event].first[:date].first).to eq({
+                                                          value: '1979', encoding: { code: 'marc' }
+                                                        })
+      end
+    end
+
+    context 'with a date range' do
+      it 'builds a structuredValue date with start and end' do
+        result = builder.build({
+                                 event: [{ type: 'creation', date_start_value: '1920', date_end_value: '1925',
+                                           _original: '{}' }]
+                               })
+        expect(result[:event].first[:date].first[:structuredValue]).to eq([
+                                                                            { value: '1920', type: 'start' },
+                                                                            { value: '1925', type: 'end' }
+                                                                          ])
+      end
+
+      it 'omits end when blank' do
+        result = builder.build({
+                                 event: [{ type: 'creation', date_start_value: '1920', date_end_value: '',
+                                           _original: '{}' }]
+                               })
+        structured = result[:event].first[:date].first[:structuredValue]
+        expect(structured).to eq([{ value: '1920', type: 'start' }])
+      end
+    end
+
+    context 'with a publisher' do
+      it 'builds a contributor with publisher role' do
+        result = builder.build({
+                                 event: [{ type: 'publication', date_value: '1978',
+                                           publisher_value: 'Acme Press', _original: '{}' }]
+                               })
+        contributor = result[:event].first[:contributor].first
+        expect(contributor[:name].first[:value]).to eq('Acme Press')
+        expect(contributor[:role]).to eq([{ value: 'publisher' }])
+        expect(contributor[:type]).to eq('organization')
+      end
+
+      it 'preserves publisher role codes from _original' do
+        original = {
+          contributor: [{ type: 'organization',
+                          name: [{ value: 'Old Press' }],
+                          role: [{ value: 'publisher', code: 'pbl',
+                                   source: { code: 'marcrelator' } }] }]
+        }.to_json
+        result = builder.build({
+                                 event: [{ type: 'publication', date_value: '1978',
+                                           publisher_value: 'New Press', _original: original }]
+                               })
+        role = result[:event].first[:contributor].first[:role].first
+        expect(role[:value]).to eq('publisher')
+        expect(role[:code]).to eq('pbl')
+      end
+    end
+
+    context 'with a place' do
+      it 'sets the location value' do
+        result = builder.build({
+                                 event: [{ type: 'publication', date_value: '1978',
+                                           place_value: 'New York', _original: '{}' }]
+                               })
+        expect(result[:event].first[:location].first[:value]).to eq('New York')
+      end
+
+      it 'preserves a MARC country code alongside the text location' do
+        original = {
+          location: [{ code: 'nyu', source: { code: 'marccountry' } },
+                     { value: 'New York' }]
+        }.to_json
+        result = builder.build({
+                                 event: [{ type: 'publication', date_value: '1978',
+                                           place_value: 'New York (State)', _original: original }]
+                               })
+        locs = result[:event].first[:location]
+        expect(locs.first[:code]).to eq('nyu')
+        expect(locs.last[:value]).to eq('New York (State)')
+      end
+    end
+
+    it 'drops events with blank type and date' do
+      result = builder.build({ event: [{ type: '', date_value: '', _original: '{}' }] })
+      expect(result[:event]).to be_nil
+    end
+
+    it 'uses raw JSON when present' do
+      raw = { type: 'broadcast', parallelEvent: [] }.to_json
+      result = builder.build({ event: [{ _raw_json: raw }] })
+      expect(result[:event].first[:type]).to eq('broadcast')
+    end
+  end
+
+  describe 'related_resource building' do
+    it 'builds a related resource with title and url' do
+      result = builder.build({
+                               related_resource: [{ title_value: 'Finding Aid', type: 'described by',
+                                                    url: 'https://example.com/fa' }]
+                             })
+      rr = result[:relatedResource].first
+      expect(rr[:title]).to eq([{ value: 'Finding Aid' }])
+      expect(rr[:access]).to eq({ url: [{ value: 'https://example.com/fa' }] })
+      expect(rr[:type]).to eq('described by')
+    end
+
+    it 'drops entries with blank title and url' do
+      result = builder.build({ related_resource: [{ title_value: '', url: '' }] })
+      expect(result[:relatedResource]).to be_nil
+    end
+
+    it 'uses raw JSON when present' do
+      raw = { type: 'part of', title: [{ value: 'Series' }] }.to_json
+      result = builder.build({ related_resource: [{ _raw_json: raw }] })
+      expect(result[:relatedResource].first[:type]).to eq('part of')
+    end
+  end
+
+  describe 'access building' do
+    let(:existing) do
+      { title: [{ value: 'T' }],
+        access: { note: [{ value: 'Existing note', type: 'access restriction' }] } }
+    end
+
+    it 'builds physical locations and access contacts' do
+      result = builder.build({
+                               access: {
+                                 physical_location: [{ value: 'PC0139', type: 'shelf locator' }],
+                                 access_contact: [{ value: 'spec@stanford.edu', type: 'email' }]
+                               }
+                             })
+      expect(result[:access][:physicalLocation]).to eq([{ value: 'PC0139', type: 'shelf locator' }])
+      expect(result[:access][:accessContact]).to eq([{ value: 'spec@stanford.edu', type: 'email' }])
+    end
+
+    it 'preserves existing access fields not in the form (e.g. note)' do
+      result = builder.build({
+                               access: { physical_location: [{ value: 'PC0139', type: 'shelf locator' }],
+                                         access_contact: [] }
+                             })
+      expect(result[:access][:note]).to eq([{ value: 'Existing note', type: 'access restriction' }])
+    end
+
+    it 'falls back to existing access when submitted access is blank' do
+      result = builder.build({ access: { physical_location: [], access_contact: [] } })
+      expect(result[:access]).to eq(existing[:access])
+    end
+
+    it 'drops blank entries' do
+      result = builder.build({
+                               access: {
+                                 physical_location: [{ value: '', type: 'shelf locator' }],
+                                 access_contact: [{ value: '', type: 'email' }]
+                               }
+                             })
+      expect(result[:access]).to eq(existing[:access])
+    end
+  end
+end

--- a/spec/services/description_builder_spec.rb
+++ b/spec/services/description_builder_spec.rb
@@ -8,20 +8,50 @@ RSpec.describe DescriptionBuilder do
   let(:existing) { { title: [{ value: 'Original title' }] } }
 
   describe '#build' do
-    it 'falls back to existing values when submitted fields are all blank' do
-      result = builder.build({ title: [{ value: '' }] })
-      expect(result[:title]).to eq([{ value: 'Original title' }])
+    it 'preserves existing fields the editor does not manage' do
+      existing[:purl] = 'https://purl.stanford.edu/bc123df4567'
+      result = builder.build({ title: [{ value: 'New title' }] })
+      expect(result[:purl]).to eq('https://purl.stanford.edu/bc123df4567')
     end
 
-    it 'preserves existing fields not present in submitted params' do
+    it 'removes a managed field when all of its items have been deleted' do
       existing[:note] = [{ value: 'Existing note', type: 'abstract' }]
       result = builder.build({ title: [{ value: 'New title' }] })
-      expect(result[:note]).to eq([{ value: 'Existing note', type: 'abstract' }])
+      expect(result).not_to have_key(:note)
+    end
+
+    it 'removes a field when its submitted items are all blank' do
+      result = builder.build({ title: [{ value: '' }] })
+      expect(result).not_to have_key(:title)
     end
 
     it 'removes nil values from the result' do
       result = builder.build({ title: [{ value: 'A title' }] })
       expect(result).not_to have_key(:note)
+    end
+  end
+
+  describe 'deleting the last item of a field' do
+    it 'removes the form when its only item is deleted' do
+      existing[:form] = [{ value: 'text', type: 'resource type' }]
+      expect(builder.build({ title: [{ value: 'A title' }] })).not_to have_key(:form)
+    end
+
+    it 'removes the subject when its only item is deleted' do
+      existing[:subject] = [{ value: 'History', type: 'topic' }]
+      expect(builder.build({ title: [{ value: 'A title' }] })).not_to have_key(:subject)
+    end
+
+    it 'removes the language when its only item is deleted' do
+      existing[:language] = [{ code: 'eng' }]
+      expect(builder.build({ title: [{ value: 'A title' }] })).not_to have_key(:language)
+    end
+
+    it 'removes the last physical location while keeping a remaining access contact' do
+      existing[:access] = { physicalLocation: [{ value: 'Stacks' }],
+                            accessContact: [{ value: 'archivist@example.edu' }] }
+      result = builder.build({ access: { access_contact: [{ value: 'archivist@example.edu' }] } })
+      expect(result[:access]).to eq({ accessContact: [{ value: 'archivist@example.edu' }] })
     end
   end
 
@@ -82,7 +112,7 @@ RSpec.describe DescriptionBuilder do
         result = builder.build({
                                  title: [{ struct_parts: [{ value: '', type: '' }], type: '' }]
                                })
-        expect(result[:title]).to eq([{ value: 'Original title' }])
+        expect(result).not_to have_key(:title)
       end
 
       it 'merges _original to preserve unexposed fields' do
@@ -104,7 +134,7 @@ RSpec.describe DescriptionBuilder do
 
       it 'drops the title when raw JSON is invalid' do
         result = builder.build({ title: [{ _raw_json: '{invalid' }] })
-        expect(result[:title]).to eq([{ value: 'Original title' }])
+        expect(result).not_to have_key(:title)
       end
     end
   end
@@ -208,6 +238,19 @@ RSpec.describe DescriptionBuilder do
     it 'drops contributors with blank name' do
       result = builder.build({ contributor: [{ name_value: '', type: 'person' }] })
       expect(result[:contributor]).to be_nil
+    end
+
+    context 'with a newly added item whose _original serializes to "null"' do
+      it 'builds the contributor instead of dropping or raising' do
+        result = builder.build({
+                                 contributor: [{ name_value: 'Summers, Ed', type: 'person',
+                                                 role_value: 'author', _original: 'null' }]
+                               })
+        contributor = result[:contributor].first
+        expect(contributor[:name]).to eq([{ value: 'Summers, Ed' }])
+        expect(contributor[:type]).to eq('person')
+        expect(contributor[:role]).to eq([{ value: 'author' }])
+      end
     end
   end
 
@@ -384,6 +427,16 @@ RSpec.describe DescriptionBuilder do
       raw = { type: 'broadcast', parallelEvent: [] }.to_json
       result = builder.build({ event: [{ _raw_json: raw }] })
       expect(result[:event].first[:type]).to eq('broadcast')
+    end
+
+    context 'with a newly added item whose _original serializes to "null"' do
+      it 'builds the event instead of raising' do
+        result = builder.build({
+                                 event: [{ type: 'publication', date_value: '1978', _original: 'null' }]
+                               })
+        expect(result[:event].first[:type]).to eq('publication')
+        expect(result[:event].first[:date]).to eq([{ value: '1978' }])
+      end
     end
   end
 


### PR DESCRIPTION
This implementation was written by Claude Code using design artifacts in https://github.com/sul-dlss-labs/cocina-editor-design/

What follows is a summary of the implementation written by Claude after implementing the design and several rounds of edits that are preserved in the chat transcript alongside the design documents.

---

This document records what was built, key decisions made during implementation, and where the final result diverged from the original `design.md`.

All three phases from the design plan were completed:

- **Titles** — simple value + type, and structured titles (main title, subtitle, part number, part name) each with an editable type select per part
- **Notes** — value + type dropdown
- **Language** — code + label
- **Contributors** — simple name or structured name + life dates, type, primary toggle, role field
- **Subjects** — flat `{value, type, source}` and flat LCSH compound headings (`structuredValue` with editable part types)
- **Events** — date, event type, publisher, place
- **Form** — fully implemented (not just extent as originally scoped); value + type + source
- **Access** — physical location and access contact
- **Related resources** — title, relationship type, URL

The route is `GET/PATCH /objects/:object_druid/description` (nested under the existing `:objects` resource using its `param: :druid` convention, not `/items` as sketched in the design).

The design's core approach (curated form for common shapes, raw JSON textarea escape hatch for everything else) proved sound and was applied consistently across all six field types that have polymorphic shapes. The boundary condition — "flat `structuredValue` → curated, nested `structuredValue` → JSON" — held up against all 11 sample objects.

The JSON escape hatch was further improved with:
- **Server-side pretty-printing** via `JSON.pretty_generate` so complex JSON is readable at a glance
- **Info callouts** explaining specifically why a given item fell back to JSON (e.g. "This event contains a structured or parallel date range and must be edited as JSON"), computed from the same conditions that triggered the fallback
- **Auto-formatting** on blur via a `json_formatter` Stimulus controller that re-indents valid JSON and flags invalid JSON with Bootstrap's `is-invalid` style
- **"Show JSON" toggle** on curated items so editors can inspect the underlying data without switching to raw editing

For fields where the form only exposes a subset of properties (events, contributors, structured titles), the full original JSON is stored in a `_original` hidden field and used as the base when rebuilding the object on save. This preserves fields not yet surfaced by the editor (MARC country codes, date encoding attributes, role URIs, etc.) without the editor needing to know about them.

Rather than relying on Stimulus to serialize the form to JSON (as the design sketched), the controller rebuilds each section from standard Rails form params via a set of `build_title`, `build_contributor`, `build_subject`, `build_event`, `build_form`, and `build_related_resource` methods. These merge submitted fields back into the existing description, preserving any fields not exposed by the editor.

In real SDR data, the event `type` is often stored on `date[0].type` rather than on the event itself. The display resolved this with:

```ruby
event_type = event[:type].presence || event.dig(:date, 0, :type)
```

This matches the logic in the `cocina_display` gem's `event.rb`.

Publication events frequently carry two location entries — a human-readable place name and a MARC country code:

```json
"location": [{"value": "New York"}, {"code": "nyu"}]
```

The original implementation replaced all locations with a single entry. The fix identifies the value-bearing entry by index and updates only that one, leaving the code entry untouched.

Publisher names in events follow the pattern:
```json
{"contributor": [{"name": [{"value": "Munn & Co."}], "type": "organization",
                  "role": [{"value": "publisher", ...}]}]}
```
This is common enough that it was promoted to a curated `publisher` field in the event form rather than left to the JSON escape hatch.

The design anticipated raw JSON for structured values. In practice, all `structuredValue` arrays in the sample data are flat (depth 1), so a curated form was built for both:

- **Titles**: each `structuredValue` part rendered as a value input + type select (main title, subtitle, part number, part name, nonsorting characters), with a separate title-level type select (alternative, uniform, translated, etc.)
- **Subjects**: flat LCSH compound headings rendered as a list of value + type select rows, preserving the full original via `_struct_original`

Deeply nested `structuredValue` (depth > 1) still falls through to the JSON textarea.

| Design | Actual |
|---|---|
| Field-level error injection via Turbo Streams | Flash warnings at page level; Turbo Stream error injection deferred | | ETag / lock field for concurrent edit protection | Not implemented; deferred | | Stimulus serializes form to JSON on submit | Standard Rails form params; controller rebuilds description | | `form` scoped to extent only | Full form field implemented (all types) | | Route `/items/:druid/description` | `/objects/:object_druid/description` (matches existing resource) | | Inline error paths from `Cocina::Models::ValidationError` | `CocinaSupport.validate` returns a `Dry::Monads::Failure` string; shown as flash |

- **Controller**: `app/controllers/descriptions_controller.rb`
- **Edit view**: `app/views/descriptions/edit.html.erb`
- **Field partials**: `app/views/descriptions/_*_fields.html.erb`
- **JSON toggle partial**: `app/views/descriptions/_json_toggle.html.erb`
- **Stimulus controllers**: `description_editor_controller.js`, `json_formatter_controller.js`
- **Request spec**: `spec/requests/descriptions_spec.rb`
- **Route**: `config/routes.rb` — `resource :description` nested under `resources :objects`
- **Policy**: `app/policies/object_policy.rb` — `edit_description?`