### PR TITLE
Extract token concern.

### DIFF
--- a/app/controllers/concerns/token_concern.rb
+++ b/app/controllers/concerns/token_concern.rb
@@ -1,0 +1,31 @@
+# frozen_string_literal: true
+
+# Concern for controllers that need to handle tokens.
+module TokenConcern
+  extend ActiveSupport::Concern
+
+  #   Controller can set:
+  #     self.token_purpose = 'download'
+  #     self.token_expires_at_builder = -> { 2.hours.from_now }
+  included do
+    class_attribute :token_purpose, default: 'default'
+    # Using fixed expires at keeps the token constant to avoid interfering with morphing.
+    class_attribute :token_expires_at_builder, default: -> { 1.week.from_now.end_of_day }
+  end
+
+  def verifier
+    Rails.application.message_verifier(:argo)
+  end
+
+  # @return [String] a token that can be used to verify the druid
+  def generate_token(value)
+    verifier.generate(value, purpose: self.class.token_purpose,
+                             expires_at: self.class.token_expires_at_builder.call)
+  end
+
+  # @return [String] the value if the token is valid, otherwise raises an error
+  # @raise [ActiveSupport::MessageVerifier::InvalidSignature] if the token is invalid
+  def verify_token(token)
+    verifier.verify(token, purpose: self.class.token_purpose)
+  end
+end

--- a/app/controllers/objects_controller.rb
+++ b/app/controllers/objects_controller.rb
@@ -4,6 +4,15 @@
 class ObjectsController < ApplicationController
   skip_verify_authorized only: %i[show_json show_workflows show_details show_header show_versions show_purl_preview]
 
+  include TokenConcern
+
+  # The strategy is to authorize on show, but not repeat authorization on other show endpoints.
+  # This avoids having to make additional calls that would be required for the authorization, but not the showing.
+  # For the other show endpoints, the druid is signed and verified to ensure that the druid is valid and was generated
+  # by the show action.
+  # Thus, the signing / verification acts as authorization for those endpoints.
+  self.token_purpose = 'show'
+
   def show
     @solr_doc = SolrDocPresenter.new(solr_doc: fetch_solr_doc(params[:druid]))
     authorize! @solr_doc, with: ObjectPolicy
@@ -13,14 +22,14 @@ class ObjectsController < ApplicationController
   end
 
   def show_header
-    @solr_doc = SolrDocPresenter.new(solr_doc: fetch_solr_doc(verify_token(params[:druid])))
+    @solr_doc = SolrDocPresenter.new(solr_doc: fetch_solr_doc(verified_druid))
 
     render layout: false
   end
 
   def show_details
     # Need to find way to avoid retrieving solr doc again.
-    @solr_doc = SolrDocPresenter.new(solr_doc: fetch_solr_doc(verify_token(params[:druid])))
+    @solr_doc = SolrDocPresenter.new(solr_doc: fetch_solr_doc(verified_druid))
 
     case @solr_doc.object_type
     when 'collection'
@@ -34,20 +43,20 @@ class ObjectsController < ApplicationController
   end
 
   def show_json
-    @cocina_hash = fetch_cocina_hash(verify_token(params[:druid]))
+    @cocina_hash = fetch_cocina_hash(verified_druid)
 
     render layout: false
   end
 
   def show_workflows
-    @druid = verify_token(params[:druid])
+    @druid = verified_druid
     @workflows = Sdr::WorkflowService.workflows_for(druid: @druid)
 
     render layout: false
   end
 
   def show_versions
-    @druid = verify_token(params[:druid])
+    @druid = verified_druid
     object_client = Dor::Services::Client.object(@druid)
     @versions_presenter = VersionsPresenter.new(version_inventory: object_client.version.inventory,
                                                 milestones: object_client.milestones.list,
@@ -55,32 +64,15 @@ class ObjectsController < ApplicationController
   end
 
   def show_purl_preview
-    @cocina_hash = fetch_cocina_hash(verify_token(params[:druid]))
+    @cocina_hash = fetch_cocina_hash(verified_druid)
     @preview = fetch_purl_preview(@cocina_hash)
     render layout: false
   end
 
   private
 
-  # The strategy is to authorize on show, but not repeat authorization on other show endpoints.
-  # This avoids having to make additional calls that would be required for the authorization, but not the showing.
-  # For the other show endpoints, the druid is signed and verified to ensure that the druid is valid and was generated
-  # by the show action.
-  # Thus, the signing / verification acts as authorization for those endpoints.
-  def verifier
-    Rails.application.message_verifier(:argo)
-  end
-
-  # @return [String] a token that can be used to verify the druid
-  def generate_token(druid)
-    # Using fixed expires at keeps the token constant for a given druid to avoid interfering with morphing.
-    verifier.generate(druid, purpose: 'show', expires_at: 1.week.from_now.end_of_day)
-  end
-
-  # @return [String] the druid if the token is valid, otherwise raises an error
-  # @raise [ActiveSupport::MessageVerifier::InvalidSignature] if the token is invalid
-  def verify_token(token)
-    verifier.verify(token, purpose: 'show')
+  def verified_druid
+    @verified_druid ||= verify_token(params[:druid])
   end
 
   def fetch_solr_doc(druid)

--- a/spec/controllers/concerns/token_concern_spec.rb
+++ b/spec/controllers/concerns/token_concern_spec.rb
@@ -1,0 +1,46 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe TokenConcern do
+  subject(:including_instance) { controller_class.new }
+
+  let(:controller_class) do
+    Class.new do
+      include TokenConcern
+    end
+  end
+
+  let(:value) { 'druid:bc123cd4567' }
+
+  describe '#verifier' do
+    it 'returns the argo message verifier' do
+      expect(including_instance.verifier).to eq(Rails.application.message_verifier(:argo))
+    end
+  end
+
+  describe '#generate_token and #verify_token' do
+    it 'round-trips a value with default configuration' do
+      token = including_instance.generate_token(value)
+
+      expect(including_instance.verify_token(token)).to eq(value)
+    end
+
+    it 'uses configured purpose and expires_at builder' do
+      expires_at = Time.zone.parse('2026-12-31 23:59:59 UTC')
+      controller_class.token_purpose = 'show'
+      controller_class.token_expires_at_builder = -> { expires_at }
+
+      token = including_instance.generate_token(value)
+
+      expect(Rails.application.message_verifier(:argo).verify(token, purpose: 'show')).to eq(value)
+    end
+
+    it 'raises when token purpose does not match' do
+      token = Rails.application.message_verifier(:argo).generate(value, purpose: 'other', expires_at: 1.day.from_now)
+
+      expect { including_instance.verify_token(token) }
+        .to raise_error(ActiveSupport::MessageVerifier::InvalidSignature)
+    end
+  end
+end


### PR DESCRIPTION
To keep the controller from growing too large and allow re-use.