### PR TITLE
Fix search box styling

### DIFF
--- a/app/assets/stylesheets/search.scss
+++ b/app/assets/stylesheets/search.scss
@@ -33,3 +33,7 @@ a[aria-expanded="false"] {
 .accordion-header.facet-field-heading .accordion-button:disabled::after {
   display: none;
 }
+
+.input-group-text {
+	border-color: var(--stanford-60-black);
+}


### PR DESCRIPTION
Before:
<img width="899" height="110" alt="image" src="https://github.com/user-attachments/assets/3178e9a9-167a-4280-a575-02cde3852049" />

After:
<img width="866" height="109" alt="image" src="https://github.com/user-attachments/assets/e3672fb6-9838-4676-a59d-9942c14137c1" />
