### PR TITLE
allow APO pages to be shown

### DIFF
--- a/app/controllers/objects_controller.rb
+++ b/app/controllers/objects_controller.rb
@@ -37,7 +37,7 @@ class ObjectsController < ApplicationController
     case @solr_doc.object_type
     when 'collection'
       render :show_collection_overview, layout: false
-    when 'admin_policy'
+    when 'adminPolicy'
       render :show_admin_policy_overview, layout: false
     else
       # This also includes agreements and virtual objects.

--- a/app/presenters/solr_doc_presenter.rb
+++ b/app/presenters/solr_doc_presenter.rb
@@ -11,7 +11,7 @@ class SolrDocPresenter < SearchResults::Item
   end
 
   def admin_policy?
-    object_type == 'admin_policy'
+    object_type == 'adminPolicy'
   end
 
   def dro?

--- a/spec/services/solr_doc_presenter_spec.rb
+++ b/spec/services/solr_doc_presenter_spec.rb
@@ -31,15 +31,15 @@ RSpec.describe SolrDocPresenter do
   end
 
   describe '#admin_policy?' do
-    context 'when the object type is admin_policy' do
-      let(:object_type) { 'admin_policy' }
+    context 'when the object type is admin policy' do
+      let(:object_type) { 'adminPolicy' }
 
       it 'returns true' do
         expect(presenter.admin_policy?).to be true
       end
     end
 
-    context 'when the object type is not admin_policy' do
+    context 'when the object type is not admin policy' do
       let(:object_type) { 'item' }
 
       it 'returns false' do
@@ -57,15 +57,15 @@ RSpec.describe SolrDocPresenter do
       end
     end
 
-    context 'when the object type is admin_policy' do
-      let(:object_type) { 'admin_policy' }
+    context 'when the object type is admin policy' do
+      let(:object_type) { 'adminPolicy' }
 
       it 'returns false' do
         expect(presenter.dro?).to be false
       end
     end
 
-    context 'when the object type is neither collection nor admin_policy' do
+    context 'when the object type is neither collection nor admin policy' do
       let(:object_type) { 'item' }
 
       it 'returns true' do

--- a/spec/system/show_admin_policy_spec.rb
+++ b/spec/system/show_admin_policy_spec.rb
@@ -21,7 +21,7 @@ RSpec.describe 'Show admin policy' do
   def build_solr_doc(title:)
     {
       Search::Fields::ID => druid,
-      Search::Fields::OBJECT_TYPES => ['admin_policy'],
+      Search::Fields::OBJECT_TYPES => ['adminPolicy'],
       Search::Fields::TITLE => title,
       Search::Fields::APO_DRUID => [apo_druid],
       Search::Fields::APO_TITLE => ['My APO'],


### PR DESCRIPTION
Current APO overview panel is broken because the logic to check object type has a typo.  Noticed this in localhost when it threw an exception trying to look at an APO page

See for example https://argo-b3-stage.stanford.edu/objects/druid:ry127nb8794 and open this same object in localhost pointing to stage

Solr doc: https://argo-stage.stanford.edu/view/druid:ry127nb8794.json