### PR TITLE
rely on cocina-models to validate barcodes

### DIFF
--- a/app/models/cocina_models/dro.rb
+++ b/app/models/cocina_models/dro.rb
@@ -166,18 +166,9 @@ module CocinaModels
         Array(location).include?(embargo_location)
     end
 
-    BARCODE_FORMATS = [
-      /^2050[0-9]{7}$/,
-      /^245[0-9]{8}$/,
-      /^[0-9]+-[0-9]+$/,
-      /^36105[0-9]{9}$/,
-      /^405[0-9]+$/
-    ].freeze
-    private_constant :BARCODE_FORMATS
-
     def validate_barcode
       return if barcode.nil?
-      return if BARCODE_FORMATS.any? { |pattern| pattern.match?(barcode) }
+      return if Cocina::Models::Barcode.valid?(barcode)
 
       errors.add(:barcode, 'is not a valid barcode')
     end

--- a/spec/models/cocina_models/dro_spec.rb
+++ b/spec/models/cocina_models/dro_spec.rb
@@ -715,6 +715,23 @@ RSpec.describe CocinaModels::Dro do
       end
     end
 
+    context 'when barcode is a valid California Historical Society barcode' do
+      before { dro.barcode = '405000111956' }
+
+      it 'is valid' do
+        expect(dro).to be_valid
+      end
+    end
+
+    context 'when barcode is a California Historical Society barcode with an invalid length' do
+      before { dro.barcode = '40500011195' }
+
+      it 'is not valid and adds a barcode error' do
+        expect(dro).not_to be_valid
+        expect(dro.errors[:barcode]).to include('is not a valid barcode')
+      end
+    end
+
     context 'when barcode is invalid' do
       before { dro.barcode = 'not-a-barcode' }
 


### PR DESCRIPTION
Fixes #196 

Instead of maintaining the regexes in argo-b3, we can just rely on cocina-models, which already has them all defined and can remain the canonical source.  

eg https://github.com/sul-dlss/cocina-models/blob/main/lib/cocina/models/barcode.rb and then https://github.com/sul-dlss/cocina-models/blob/main/lib/cocina/models/catkey_barcode.rb etc.