### PR TITLE
check/start docker containers in dev-server script

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -47,3 +47,6 @@ config/environments/*.local.yml
 /coverage
 
 .ruby-version
+
+# Ignore local Claude Code settings (personal permission approvals, etc.).
+.claude/settings.local.json

--- a/.gitignore
+++ b/.gitignore
@@ -47,6 +47,3 @@ config/environments/*.local.yml
 /coverage
 
 .ruby-version
-
-# Ignore local Claude Code settings (personal permission approvals, etc.).
-.claude/settings.local.json

--- a/bin/dev-server
+++ b/bin/dev-server
@@ -30,16 +30,11 @@ fi
 
 # db and redis are the only local containers this script needs; Solr, DSA,
 # and PresCat are tunneled to the remote server environment instead.
-ensure_docker_services() {
-  if ! docker info >/dev/null 2>&1; then
-    echo "Docker does not appear to be running. Please start Docker and try again." >&2
-    exit 1
-  fi
-
-  docker compose up -d db redis
-}
-
-ensure_docker_services
+if ! docker info >/dev/null 2>&1; then
+  echo "Docker does not appear to be running. Please start Docker and try again." >&2
+  exit 1
+fi
+docker compose up -d db redis
 
 # check for dlss-capistrano's controlmaster:setup/:start tasks:
 # https://github.com/sul-dlss/dlss-capistrano/blob/main/lib/dlss/capistrano/tasks/control_master.rake

--- a/bin/dev-server
+++ b/bin/dev-server
@@ -28,6 +28,19 @@ if [ -z "$SETTINGS__DOR_SERVICES__TOKEN" ] || [ -z "$SETTINGS__PRESERVATION_CATA
   exit 1
 fi
 
+# db and redis are the only local containers this script needs; Solr, DSA,
+# and PresCat are tunneled to the remote server environment instead.
+ensure_docker_services() {
+  if ! docker info >/dev/null 2>&1; then
+    echo "Docker does not appear to be running. Please start Docker and try again." >&2
+    exit 1
+  fi
+
+  docker compose up -d db redis
+}
+
+ensure_docker_services
+
 # check for dlss-capistrano's controlmaster:setup/:start tasks:
 # https://github.com/sul-dlss/dlss-capistrano/blob/main/lib/dlss/capistrano/tasks/control_master.rake
 ensure_controlmaster() {


### PR DESCRIPTION
1. dev-server script will verify docker daemon is running and then ensure the db and redis containers are up in the background
2. unrelated change, ensure we don't inadvertently check-in a person specific claude settings.json file