### PR TITLE
Fix release tag "to" value; allow dev job queue management

### DIFF
--- a/app/policies/mission_control/jobs/queues_policy.rb
+++ b/app/policies/mission_control/jobs/queues_policy.rb
@@ -10,7 +10,7 @@ module MissionControl
       alias_rule :index?, :create?, :new?, to: :manage?
 
       def manage?
-        admin?
+        admin? || Rails.env.development?
       end
     end
   end

--- a/app/services/sdr/repository.rb
+++ b/app/services/sdr/repository.rb
@@ -87,7 +87,7 @@ module Sdr
     # @param [String] lane_id lane to using for releaseWF (high, default, or low) if object has been published
     def self.create_release_tag(druid:, user_name:, release_target:, release:, release_what: 'self', lane_id: 'high') # rubocop:disable Metrics/ParameterLists
       new_tag = Dor::Services::Client::ReleaseTag.new(
-        **{ to: release_target }.compact, # "to" must be omitted when nil.
+        to: release_target || '', # "to" must be a string; released_to is NOT NULL in DSA DB.
         who: user_name,
         what: release_what,
         release:,

--- a/spec/services/sdr/repository_spec.rb
+++ b/spec/services/sdr/repository_spec.rb
@@ -232,11 +232,11 @@ RSpec.describe Sdr::Repository do
     end
 
     context 'when release_target is nil' do
-      it 'creates a release tag without a to' do
+      it 'creates a release tag with a blank to' do
         described_class.create_release_tag(druid:, user_name:, release_target: nil, release: false)
 
         expect(release_tags_client).to have_received(:create) do |tag:, lane_id:|
-          expect(tag.to).to be_nil
+          expect(tag.to).to eq('')
           expect(lane_id).to eq('high')
         end
       end


### PR DESCRIPTION
## Summary
- `Sdr::Repository.create_release_tag` now sends `to: ''` instead of omitting the key when `release_target` is nil — DSA's `released_to` DB column is `NOT NULL`, so omitting it produced an invalid request.
- Allow Mission Control job queue management in development without admin rights, to make local debugging easier.

Split out of the t310-dropzone branch as an unrelated drive-by fix (see plan for the full PR breakdown of that branch).

## Test plan
- [x] `bundle exec rspec spec/services/sdr/repository_spec.rb` passes