### PR TITLE
Extract access fields into AccessConcern; build out AdminPolicy

### DIFF
--- a/app/models/cocina_models/admin_policy.rb
+++ b/app/models/cocina_models/admin_policy.rb
@@ -3,6 +3,8 @@
 module CocinaModels
   # Model for a Cocina AdminPolicy object.
   class AdminPolicy < Base
+    include AccessConcern
+
     # @param cocina_object [Cocina::Models::AdminPolicyWithMetadata] the Cocina object to build this model from
     def self.build_from_cocina_object(cocina_object)
       unless cocina_object.is_a?(Cocina::Models::AdminPolicyWithMetadata)
@@ -12,11 +14,35 @@ module CocinaModels
       super
     end
 
+    attribute :agreement_druid, :string
+    validates :agreement_druid, presence: true
+
     private
 
-    def model_attrs_for(_cocina_object)
-      # Not yet implemented.
-      {}
+    def model_attrs_for(cocina_object)
+      CocinaModelMappers::AdminPolicyMapper.call(cocina_object:)
+    end
+
+    def request_cocina_object
+      Cocina::Models.build_request(
+        {
+          type: Cocina::Models::ObjectType.admin_policy,
+          administrative: {
+            hasAdminPolicy: admin_policy_druid,
+            hasAgreement: agreement_druid,
+            accessTemplate: {
+              view: access_view,
+              download: access_download,
+              location: access_location,
+              copyright:,
+              license:,
+              useAndReproductionStatement: use_and_reproduction_statement
+            }
+          },
+          description: description_hash,
+          version: 1
+        }
+      )
     end
   end
 end

--- a/app/models/cocina_models/dro.rb
+++ b/app/models/cocina_models/dro.rb
@@ -4,6 +4,7 @@ module CocinaModels
   # Model for a Cocina DRO object.
   class Dro < Base
     include CatalogLinksConcern
+    include AccessConcern
 
     # @param cocina_object [Cocina::Models::DROWithMetadata] the Cocina object to build this model from
     def self.build_from_cocina_object(cocina_object)
@@ -22,16 +23,6 @@ module CocinaModels
     normalizes_whitespace :barcode
     validate :validate_barcode
 
-    # Access fields
-    attribute :use_and_reproduction_statement, :string
-    attribute :license, :string
-    attribute :copyright, :string
-    attribute :access_view, :string
-    attribute :access_download, :string
-    attribute :access_location, :string
-    # Note that the error is reported on :access, not :access_view, :access_download, or :access_location
-    validate :validate_access
-
     # Embargo fields
     attribute :embargo_release_date, :datetime
     attribute :embargo_view, :string
@@ -47,30 +38,6 @@ module CocinaModels
     validates :content_type, inclusion: { in: Cocina::Models::DRO::TYPES }
     validates :viewing_direction, inclusion: { in: Constants::VIEWING_DIRECTIONS }, allow_nil: true
     validate :viewing_direction_only_for_applicable_content_types
-
-    def dark_access?
-      match_access?(view: 'dark', download: 'none')
-    end
-
-    def citation_only_access?
-      match_access?(view: 'citation-only', download: 'none')
-    end
-
-    def location_based_access?
-      match_access?(view: 'location-based', download: %w[location-based none], location: Constants::ACCESS_LOCATIONS)
-    end
-
-    def location_based_download_access?
-      match_access?(view: %w[stanford world], download: 'location-based', location: Constants::ACCESS_LOCATIONS)
-    end
-
-    def stanford_access?
-      match_access?(view: 'stanford', download: 'stanford')
-    end
-
-    def world_access?
-      match_access?(view: 'world', download: %w[world stanford none])
-    end
 
     def embargo_dark_access?
       match_embargo_access?(view: 'dark', download: 'none')
@@ -132,17 +99,6 @@ module CocinaModels
       errors.add(:viewing_direction, 'is only valid for book and image content types')
     end
 
-    def validate_access
-      return if dark_access? ||
-                citation_only_access? ||
-                location_based_access? ||
-                location_based_download_access? ||
-                stanford_access? ||
-                world_access?
-
-      errors.add(:access, 'is not valid')
-    end
-
     def validate_embargo_access
       return if embargo_dark_access? ||
                 embargo_citation_only_access? ||
@@ -152,12 +108,6 @@ module CocinaModels
                 embargo_world_access?
 
       errors.add(:embargo_access, 'is not valid')
-    end
-
-    def match_access?(view:, download:, location: [nil])
-      Array(view).include?(access_view) &&
-        Array(download).include?(access_download) &&
-        Array(location).include?(access_location)
     end
 
     def match_embargo_access?(view:, download:, location: [nil])

--- a/app/models/concerns/cocina_models/access_concern.rb
+++ b/app/models/concerns/cocina_models/access_concern.rb
@@ -1,0 +1,63 @@
+# frozen_string_literal: true
+
+module CocinaModels
+  # Concern for handling access in Cocina models.
+  module AccessConcern
+    extend ActiveSupport::Concern
+
+    included do # rubocop:disable Metrics/BlockLength
+      # Access fields
+      attribute :use_and_reproduction_statement, :string
+      attribute :license, :string
+      attribute :copyright, :string
+      attribute :access_view, :string
+      attribute :access_download, :string
+      attribute :access_location, :string
+      # Note that the error is reported on :access, not :access_view, :access_download, or :access_location
+      validate :validate_access
+
+      def validate_access
+        return if dark_access? ||
+                  citation_only_access? ||
+                  location_based_access? ||
+                  location_based_download_access? ||
+                  stanford_access? ||
+                  world_access?
+
+        errors.add(:access, 'is not valid')
+      end
+
+      def dark_access?
+        match_access?(view: 'dark', download: 'none')
+      end
+
+      def citation_only_access?
+        match_access?(view: 'citation-only', download: 'none')
+      end
+
+      def location_based_access?
+        match_access?(view: 'location-based', download: %w[location-based none], location: Constants::ACCESS_LOCATIONS)
+      end
+
+      def location_based_download_access?
+        match_access?(view: %w[stanford world], download: 'location-based', location: Constants::ACCESS_LOCATIONS)
+      end
+
+      def stanford_access?
+        match_access?(view: 'stanford', download: 'stanford')
+      end
+
+      def world_access?
+        match_access?(view: 'world', download: %w[world stanford none])
+      end
+
+      private
+
+      def match_access?(view:, download:, location: [nil])
+        Array(view).include?(access_view) &&
+          Array(download).include?(access_download) &&
+          Array(location).include?(access_location)
+      end
+    end
+  end
+end

--- a/app/services/cocina_model_mappers/admin_policy_mapper.rb
+++ b/app/services/cocina_model_mappers/admin_policy_mapper.rb
@@ -1,0 +1,33 @@
+# frozen_string_literal: true
+
+module CocinaModelMappers
+  # Mapper for a Cocina AdminPolicy to the attributes for a CocinaModels::AdminPolicy.
+  class AdminPolicyMapper
+    def self.call(...)
+      new(...).call
+    end
+
+    # @param cocina_object [Cocina::Models::AdminPolicyWithMetadata]
+    def initialize(cocina_object:)
+      @cocina_object = cocina_object
+    end
+
+    # @return [Hash] the mapped attributes
+    def call # rubocop:disable Metrics/AbcSize
+      {
+        access_view: cocina_object.administrative.accessTemplate.view,
+        access_download: cocina_object.administrative.accessTemplate.download,
+        access_location: cocina_object.administrative.accessTemplate.location,
+        use_and_reproduction_statement: cocina_object.administrative.accessTemplate.useAndReproductionStatement,
+        license: cocina_object.administrative.accessTemplate.license,
+        copyright: cocina_object.administrative.accessTemplate.copyright,
+        admin_policy_druid: cocina_object.administrative.hasAdminPolicy,
+        agreement_druid: cocina_object.administrative.hasAgreement
+      }.compact
+    end
+
+    private
+
+    attr_reader :cocina_object
+  end
+end

--- a/compose.yaml
+++ b/compose.yaml
@@ -42,10 +42,12 @@ services:
       SETTINGS__REDIS_URL: redis://redis:6379/
       SETTINGS__ROBOTS_REDIS_URL: redis://redis:6379/
       SETTINGS__RELEASE__PURL_BASE_URL: https://sul-purl-stage.stanford.edu
+      SETTINGS__SOLR__URL: http://solr:8983/solr/argo
     depends_on:
       - db
       - suri
       - redis
+      - solr
 
   suri:
     image: suldlss/suri-rails:latest

--- a/lib/tasks/development.rake
+++ b/lib/tasks/development.rake
@@ -1,0 +1,20 @@
+# frozen_string_literal: true
+
+namespace :development do
+  desc 'Bootstrap an AdminPolicy for local development use'
+  task :bootstrap_apo, [:title] => :environment do |_t, args|
+    raise 'This task can only be run in the development environment' unless Rails.env.development?
+
+    admin_policy = CocinaModels::AdminPolicy.new(
+      # This contains arbitrary hardcoded values; in the future, may want to make more flexible.
+      admin_policy_druid: 'druid:hv992ry2431',
+      agreement_druid: 'druid:hp308wm0436',
+      access_view: 'world',
+      access_download: 'world',
+      description_hash: { title: [{ value: args[:title] }] }
+    )
+    admin_policy.create!(user_name: 'auser')
+
+    puts admin_policy.druid
+  end
+end

--- a/spec/models/cocina_models/admin_policy_spec.rb
+++ b/spec/models/cocina_models/admin_policy_spec.rb
@@ -11,6 +11,7 @@ RSpec.describe CocinaModels::AdminPolicy do
     context 'with a valid Cocina::Models::AdminPolicyWithMetadata' do
       it 'initializes with a Cocina::Models::AdminPolicyWithMetadata' do
         expect(admin_policy.external_identifier).to eq(cocina_object.externalIdentifier)
+        expect(admin_policy.agreement_druid).to eq(cocina_object.administrative.hasAgreement)
       end
     end
 
@@ -34,6 +35,80 @@ RSpec.describe CocinaModels::AdminPolicy do
 
     it 'returns true for #admin_policy?' do
       expect(admin_policy.admin_policy?).to be true
+    end
+  end
+
+  describe 'agreement_druid' do
+    context 'when blank' do
+      before { admin_policy.agreement_druid = nil }
+
+      it 'is not valid' do
+        expect(admin_policy).not_to be_valid
+        expect(admin_policy.errors[:agreement_druid]).to include("can't be blank")
+      end
+    end
+  end
+
+  describe '#create!' do
+    let(:user_name) { 'test_user' }
+
+    context 'when the object has already been persisted' do
+      it 'raises' do
+        expect { admin_policy.create!(user_name:) }.to raise_error(/already been persisted/)
+      end
+    end
+
+    context 'when the object has not been persisted' do
+      let(:new_admin_policy) do
+        described_class.new(agreement_druid: 'druid:bb008zm4587',
+                            access_view: 'world', access_download: 'world',
+                            admin_policy_druid: 'druid:hv992ry2431')
+      end
+      let(:request_cocina_object) { instance_double(Cocina::Models::RequestAdminPolicy) }
+      let(:registered_cocina_object) { build(:admin_policy_with_metadata) }
+
+      before do
+        allow(new_admin_policy).to receive(:request_cocina_object).and_return(request_cocina_object)
+        allow(Sdr::Repository).to receive(:register).and_return(registered_cocina_object)
+      end
+
+      it 'registers the object and repopulates the model' do
+        new_admin_policy.create!(user_name:)
+
+        expect(Sdr::Repository).to have_received(:register)
+          .with(request_cocina_object:, user_name:)
+        expect(new_admin_policy.persisted?).to be true
+        expect(new_admin_policy.external_identifier).to eq(registered_cocina_object.externalIdentifier)
+        expect(new_admin_policy.changed?).to be false
+      end
+    end
+
+    context 'when building the real request cocina object' do
+      let(:new_admin_policy) do
+        described_class.new(agreement_druid: 'druid:bb008zm4587',
+                            access_view: 'world', access_download: 'world',
+                            admin_policy_druid: 'druid:hv992ry2431')
+      end
+      let(:registered_cocina_object) { build(:admin_policy_with_metadata) }
+
+      before do
+        allow(Sdr::Repository).to receive(:register).and_return(registered_cocina_object)
+      end
+
+      it 'constructs and registers a valid Cocina::Models::RequestAdminPolicy' do
+        new_admin_policy.create!(user_name:)
+
+        expect(Sdr::Repository).to have_received(:register) do |args|
+          request_cocina_object = args[:request_cocina_object]
+          expect(request_cocina_object).to be_a(Cocina::Models::RequestAdminPolicy)
+          expect(request_cocina_object.administrative.hasAdminPolicy).to eq('druid:hv992ry2431')
+          expect(request_cocina_object.administrative.hasAgreement).to eq('druid:bb008zm4587')
+          expect(request_cocina_object.administrative.accessTemplate.view).to eq('world')
+          expect(request_cocina_object.administrative.accessTemplate.download).to eq('world')
+
+          expect(args[:user_name]).to eq(user_name)
+        end
+      end
     end
   end
 end

--- a/spec/services/cocina_model_mappers/admin_policy_mapper_spec.rb
+++ b/spec/services/cocina_model_mappers/admin_policy_mapper_spec.rb
@@ -1,0 +1,74 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe CocinaModelMappers::AdminPolicyMapper do
+  describe '.call' do
+    subject(:result) { described_class.call(cocina_object:) }
+
+    let(:license) { 'https://creativecommons.org/publicdomain/zero/1.0/legalcode' }
+    let(:use_and_reproduction_statement) { 'This is a use and reproduction statement.' }
+    let(:copyright) { 'Copyright © Stanford University. All Rights Reserved.' }
+    let(:view) { 'stanford' }
+    let(:download) { 'location-based' }
+    let(:location) { Constants::ACCESS_LOCATIONS.first }
+    let(:admin_policy_druid) { 'druid:hv992ry2431' }
+    let(:agreement_druid) { 'druid:bb008zm4587' }
+
+    let(:cocina_object) do
+      build(:admin_policy_with_metadata).new(
+        administrative: {
+          hasAdminPolicy: admin_policy_druid,
+          hasAgreement: agreement_druid,
+          accessTemplate: {
+            view:,
+            download:,
+            location:,
+            useAndReproductionStatement: use_and_reproduction_statement,
+            license:,
+            copyright:
+          }
+        }
+      )
+    end
+
+    it 'returns a hash from the cocina object' do
+      expect(result).to eq(
+        access_view: view,
+        access_download: download,
+        access_location: location,
+        use_and_reproduction_statement:,
+        license:,
+        copyright:,
+        admin_policy_druid:,
+        agreement_druid:
+      )
+    end
+
+    context 'when the cocina object has no location, use statement, license, or copyright' do
+      let(:view) { 'world' }
+      let(:download) { 'world' }
+      let(:cocina_object) do
+        build(:admin_policy_with_metadata).new(
+          administrative: {
+            hasAdminPolicy: admin_policy_druid,
+            hasAgreement: agreement_druid,
+            accessTemplate: {
+              view:,
+              download:
+            }
+          }
+        )
+      end
+
+      it 'omits the blank attributes' do
+        expect(result).to eq(
+          access_view: view,
+          access_download: download,
+          admin_policy_druid:,
+          agreement_druid:
+        )
+      end
+    end
+  end
+end


### PR DESCRIPTION
The motivation for this work is to allow bootstrapping APOs for local development work.

## Summary
- Extract `Dro`'s access fields (`use_and_reproduction_statement`, `license`, `copyright`, `access_view`/`download`/`location`) and predicates (`dark_access?`, `world_access?`, etc.) into a shared `CocinaModels::AccessConcern`, included by both `Dro` and `AdminPolicy`.
- Implement `AdminPolicy#model_attrs_for` (previously a stub returning `{}`) via a new `CocinaModelMappers::AdminPolicyMapper`, and add `AdminPolicy#request_cocina_object`/`agreement_druid`.
- Add `lib/tasks/development.rake` (`development:bootstrap_apo`) to create a usable AdminPolicy locally, and add the `solr` service dependency to `compose.yaml` that admin policy lookups need in development.

Part 2 of splitting up the t310-dropzone branch into smaller PRs (see #337 for part 1). This PR has no dependency on the Content/file-staging work — it's pure `CocinaModels::AdminPolicy` refactoring plus dev tooling.

Note: this was rebased onto current `main` rather than cherry-picked wholesale, since `Dro`'s barcode validation had since been modernized on `main` (now uses `Cocina::Models::Barcode.valid?` instead of a hand-rolled regex) — that improvement is preserved.

## Test plan
- [x] `bundle exec rspec spec/models/cocina_models/dro_spec.rb spec/models/cocina_models/admin_policy_spec.rb spec/services/cocina_model_mappers/admin_policy_mapper_spec.rb` — 86 examples, 0 failures
- [x] `bundle exec rspec` (full suite) — passes except 2 pre-existing failures unrelated to this change (`admin/groups_spec.rb`, `mission_control_jobs_spec.rb`), confirmed failing on `main` too
- [x] `bundle exec rubocop` on changed files — no offenses