### PR TITLE
Add Content data model (Content/ContentFileSet/ContentFile/ContentFileBinary)

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -49,10 +49,13 @@ gem 'cocina-models'
 gem 'config'
 gem 'csv'
 gem 'dor-services-client'
+gem 'druid-tools'
 gem 'dry-monads'
 gem 'honeybadger'
+gem 'marcel' # For MIME type detection
 gem 'mission_control-jobs'
 gem 'okcomputer'
+gem 'positioning' # For ordering ContentFileSets and ContentFiles
 gem 'prawn', '~> 2'  # PDF generation; used in TracksheetService
 gem 'prawn-table'    # table support for Prawn PDFs
 gem 'preservation-client'
@@ -62,6 +65,7 @@ gem 'roo' # work with newer Excel files and other types (xlsx, ods, csv).
 gem 'rsolr'
 gem 'rubyzip'
 gem 'sdr_view_components'
+gem 'state_machines-activerecord'
 gem 'view_component'
 
 group :development, :test do

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -420,6 +420,9 @@ GEM
     pg (1.6.3-x86_64-darwin)
     pg (1.6.3-x86_64-linux)
     pg (1.6.3-x86_64-linux-musl)
+    positioning (0.4.8)
+      activerecord (>= 6.1)
+      activesupport (>= 6.1)
     pp (0.6.4)
       prettyprint
     prawn (2.5.0)
@@ -616,6 +619,13 @@ GEM
       net-ssh (>= 2.8.0)
       ostruct
     ssrf_filter (1.5.0)
+    state_machines (0.202.0)
+    state_machines-activemodel (0.200.0)
+      activemodel (>= 7.2)
+      state_machines (>= 0.200.0)
+    state_machines-activerecord (0.200.0)
+      activerecord (>= 7.2)
+      state_machines-activemodel (>= 0.200.0)
     stimulus-rails (1.3.4)
       railties (>= 6.0.0)
     super_diff (0.19.0)
@@ -696,6 +706,7 @@ DEPENDENCIES
   cyperful
   debug
   dor-services-client
+  druid-tools
   dry-monads
   erb_lint
   factory_bot_rails
@@ -706,11 +717,13 @@ DEPENDENCIES
   jbuilder
   kamal
   lookbook
+  marcel
   mission_control-jobs
   okcomputer
   overmind
   parallel_tests
   pg
+  positioning
   prawn (~> 2)
   prawn-table
   preservation-client
@@ -736,6 +749,7 @@ DEPENDENCIES
   solid_cable
   solid_cache
   solid_queue
+  state_machines-activerecord
   stimulus-rails
   thruster
   turbo-rails

--- a/app/models/content.rb
+++ b/app/models/content.rb
@@ -1,0 +1,24 @@
+# frozen_string_literal: true
+
+# Model for the structure (content) of an object
+#
+# Note that when a Content is marked as immutable, it means that the content
+# reflects the actual content for the specific version of the cocina object identified by the lock.
+# Lock is an attribute of this model and records the lock (ETAG) of the cocina object.
+# When Content is marked as not immutable, it means that the content is being
+# updated, e.g., as part of managing files, and may have deviated from the actual content.
+class Content < ApplicationRecord
+  has_many :content_file_sets, -> { order(:position) }, inverse_of: :content, dependent: :destroy
+  has_many :content_files, through: :content_file_sets
+  has_many :content_file_binaries, inverse_of: :content, dependent: :destroy
+
+  state_machine :staging_state, initial: :staging_not_in_progress do
+    event :staging_started do
+      transition staging_not_in_progress: :staging
+    end
+
+    event :staging_completed do
+      transition staging: :staging_not_in_progress
+    end
+  end
+end

--- a/app/models/content_file.rb
+++ b/app/models/content_file.rb
@@ -1,0 +1,17 @@
+# frozen_string_literal: true
+
+# Model for a Cocina::Models::File as it occurs within a particular ContentFileSet.
+# The underlying binary (shared across ContentFileSets when the same file is referenced more than once)
+# is modeled by ContentFileBinary.
+class ContentFile < ApplicationRecord
+  belongs_to :content_file_set
+  belongs_to :content_file_binary
+  positioned on: :content_file_set
+
+  delegate :filepath, :basename, :extname, :path_parts, :size, :md5_digest, :sha1_digest,
+           :file_location, :file, :filename, :mime_type, to: :content_file_binary
+
+  # The deposit validation scope validates that the File can be updated in SDR.
+  # In earlier parts of the flow for managing files, some of these fields may not be populated / in correct state.
+  validates :external_identifier, presence: true, on: :deposit
+end

--- a/app/models/content_file_binary.rb
+++ b/app/models/content_file_binary.rb
@@ -1,0 +1,45 @@
+# frozen_string_literal: true
+
+# Model for the binary content shared by a file, which may be referenced by multiple ContentFileSets
+# (via ContentFile) within the same Content.
+class ContentFileBinary < ApplicationRecord
+  before_save :set_filepath_parts
+
+  belongs_to :content
+  has_many :content_files, inverse_of: :content_file_binary, dependent: :destroy
+
+  has_one_attached :file
+
+  # Note that the flow of a file to different locations is: attached or globus or mount -> stage -> deposited
+  enum :file_location,
+       {
+         attached: 'attached', # File is attached to this record as an Active Storage Blob.
+         deposited: 'deposited', # File has already been accessioned and stored in preservation / stacks.
+         globus: 'globus', # File is on globus storage.
+         stage: 'stage', # File has been moved to staging storage (and therefore ready for accessioning).
+         mount: 'mount' # File is located on a mount.
+       },
+       prefix: true
+
+  # The deposit validation scope validates that the binary can be updated in SDR.
+  # In earlier parts of the flow for managing files, some of these fields may not be populated / in correct state.
+  validates :size, :md5_digest, :sha1_digest, :mime_type, presence: true, on: :deposit
+  validates :file_location, inclusion: { in: %w[stage deposited] }, on: :deposit
+
+  def filename
+    FilenameSupport.filename(filepath:)
+  end
+
+  def filepath_on_disk
+    # Globus and mount to be added.
+    ActiveStorageSupport.filepath_for_blob(file.blob)
+  end
+
+  private
+
+  def set_filepath_parts
+    self.path_parts = FilenameSupport.path_parts(filepath:)
+    self.basename = FilenameSupport.basename(filepath:)
+    self.extname = FilenameSupport.extname(filepath:)
+  end
+end

--- a/app/models/content_file_set.rb
+++ b/app/models/content_file_set.rb
@@ -1,0 +1,12 @@
+# frozen_string_literal: true
+
+# Model for a Cocina::Models::FileSet
+class ContentFileSet < ApplicationRecord
+  belongs_to :content
+  positioned on: :content
+  has_many :content_files, -> { order(:position) }, inverse_of: :content_file_set, dependent: :destroy
+
+  # The deposit validation scope validates that the FileSet can be updated in SDR.
+  # In earlier parts of the flow for managing files, this field may not be populated.
+  validates :external_identifier, presence: true, on: :deposit
+end

--- a/app/services/cocina_object_mutators/structural_mutator.rb
+++ b/app/services/cocina_object_mutators/structural_mutator.rb
@@ -1,0 +1,116 @@
+# frozen_string_literal: true
+
+module CocinaObjectMutators
+  # Mutator for rebuilding a Cocina DRO's structural.contains from a Content.
+  class StructuralMutator
+    FILE_SET_TYPE_PREFIX = 'https://cocina.sul.stanford.edu/models/resources/'
+
+    def self.call(...)
+      new(...).call
+    end
+
+    # @param cocina_object [Cocina::Models::DRO, Cocina::Models::DROWithMetadata] the Cocina object to mutate
+    # @param content [Content] the Content to serialize into the Cocina object's structural.contains
+    def initialize(cocina_object:, content:)
+      unless cocina_object.is_a?(Cocina::Models::DRO) || cocina_object.is_a?(Cocina::Models::DROWithMetadata)
+        raise ArgumentError, 'Expected a Cocina::Models::DRO or Cocina::Models::DROWithMetadata'
+      end
+
+      @cocina_object = cocina_object
+      @content = content
+    end
+
+    # @return [Cocina::Models::DRO, Cocina::Models::DROWithMetadata] a new Cocina object with structural.contains
+    #   rebuilt from the Content
+    # @raise [ActiveRecord::RecordInvalid] if any ContentFileSet or ContentFile is not valid for the deposit context
+    def call
+      validate_deposit!
+      cocina_object.new(structural: cocina_object.structural.new(contains: build_file_sets))
+    end
+
+    private
+
+    attr_reader :cocina_object, :content
+
+    def validate_deposit!
+      content.content_file_sets.each do |content_file_set|
+        raise ActiveRecord::RecordInvalid, content_file_set unless content_file_set.valid?(:deposit)
+
+        content_file_set.content_files.each do |content_file|
+          raise ActiveRecord::RecordInvalid, content_file unless content_file.valid?(:deposit)
+          unless content_file.content_file_binary.valid?(:deposit)
+            raise ActiveRecord::RecordInvalid, content_file.content_file_binary
+          end
+        end
+      end
+    end
+
+    def build_file_sets
+      content.content_file_sets.map { |content_file_set| build_file_set(content_file_set) }
+    end
+
+    def build_file_set(content_file_set)
+      {
+        type: "#{FILE_SET_TYPE_PREFIX}#{content_file_set.file_set_type}",
+        externalIdentifier: content_file_set.external_identifier,
+        label: content_file_set.label,
+        version: cocina_object.version,
+        structural: { contains: build_files(content_file_set) }
+      }
+    end
+
+    def build_files(content_file_set)
+      content_file_set.content_files.map { |content_file| build_file(content_file) }
+    end
+
+    def build_file(content_file)
+      {
+        type: Cocina::Models::ObjectType.file,
+        externalIdentifier: content_file.external_identifier,
+        label: content_file.label,
+        filename: content_file.filepath,
+        version: cocina_object.version,
+        size: content_file.size,
+        hasMimeType: content_file.mime_type,
+        languageTag: content_file.language_tag,
+        use: content_file.use,
+        sdrGeneratedText: content_file.sdr_generated_text,
+        correctedForAccessibility: content_file.corrected_for_accessibility,
+        hasMessageDigests: message_digests(content_file),
+        access: access_props(content_file),
+        administrative: administrative_props(content_file),
+        presentation: presentation_props(content_file)
+      }.compact
+    end
+
+    def message_digests(content_file)
+      [
+        { type: 'md5', digest: content_file.md5_digest },
+        { type: 'sha1', digest: content_file.sha1_digest }
+      ]
+    end
+
+    def access_props(content_file)
+      {
+        view: content_file.view,
+        download: content_file.download,
+        location: content_file.location
+      }
+    end
+
+    def administrative_props(content_file)
+      {
+        publish: content_file.publish,
+        sdrPreserve: content_file.preserve,
+        shelve: content_file.shelve
+      }
+    end
+
+    def presentation_props(content_file)
+      {}.tap do |presentation|
+        presentation[:height] = content_file.height
+        presentation[:width] = content_file.width
+      end.compact.presence
+    end
+  end
+end

--- a/app/services/contents/builder.rb
+++ b/app/services/contents/builder.rb
@@ -1,0 +1,183 @@
+# frozen_string_literal: true
+
+module Contents
+  # Builds a Content (with its ContentFileSets, ContentFileBinaries, and ContentFiles) from a Cocina
+  # object's structural metadata. Cocina files that share the same filename within the Content are
+  # deduplicated into a single ContentFileBinary, referenced by multiple ContentFiles.
+  class Builder
+    FILE_SET_TYPE_PREFIX = 'https://cocina.sul.stanford.edu/models/resources/'
+
+    # Adding in batches with insert_all! is much faster than individual creates.
+    BATCH_SIZE = 1000
+
+    def self.call(...)
+      new(...).call
+    end
+
+    # @param cocina_object [Cocina::Models::DROWithMetadata] the Cocina object to build Content for
+    # @param immutable [Boolean] true if the Content should be marked as non-changing
+    def initialize(cocina_object:, immutable: true)
+      @cocina_object = cocina_object
+      @immutable = immutable
+    end
+
+    # @return [Content] the persisted Content built from the Cocina object's structural metadata
+    def call
+      # `insert_all` is being used for efficient DB updates (instead of many small updates)
+      ActiveRecord::Base.transaction do
+        content = Content.create!(druid: cocina_object.externalIdentifier, lock: cocina_object.lock, immutable:)
+        file_set_pairs = build_content_file_sets(content:)
+        binary_ids_by_filepath = build_content_file_binaries(content:, file_set_pairs:)
+        build_content_files(file_set_pairs:, binary_ids_by_filepath:)
+        content
+      end
+    end
+
+    private
+
+    attr_reader :cocina_object, :immutable
+
+    def cocina_file_sets
+      Array(cocina_object.structural&.contains)
+    end
+
+    # @return [Array<Array(Cocina::Models::FileSet, Integer)>] each cocina file set paired with the id of its
+    #   newly-inserted ContentFileSet
+    def build_content_file_sets(content:)
+      return [] if cocina_file_sets.empty?
+
+      attrs = cocina_file_sets.each_with_index.map do |cocina_file_set, index|
+        content_file_set_attrs(content:, cocina_file_set:, position: index + 1)
+      end
+
+      ids = attrs.each_slice(BATCH_SIZE).flat_map do |batch|
+        ContentFileSet.insert_all!(batch, returning: [:id]).rows.flatten # rubocop:disable Rails/SkipsModelValidations
+      end
+
+      cocina_file_sets.zip(ids) # Pairs id with cocina file
+    end
+
+    def content_file_set_attrs(content:, cocina_file_set:, position:)
+      {
+        content_id: content.id,
+        position:,
+        file_set_type: cocina_file_set.type.delete_prefix(FILE_SET_TYPE_PREFIX),
+        label: cocina_file_set.label,
+        external_identifier: cocina_file_set.externalIdentifier
+      }
+    end
+
+    # @return [Hash<String, Integer>] the id of the newly-inserted ContentFileBinary for each distinct filename
+    #   referenced by the Cocina object's file sets
+    def cocina_files_by_filepath(file_set_pairs:)
+      file_set_pairs.each_with_object({}) do |(cocina_file_set, _id), memo|
+        Array(cocina_file_set.structural&.contains).each do |cocina_file|
+          memo[cocina_file.filename] ||= cocina_file
+        end
+      end
+    end
+
+    def build_content_file_binaries(content:, file_set_pairs:)
+      cocina_files_by_filepath = cocina_files_by_filepath(file_set_pairs:)
+
+      return {} if cocina_files_by_filepath.empty?
+
+      filepaths = cocina_files_by_filepath.keys
+      attrs = cocina_files_by_filepath.map do |filepath, cocina_file|
+        content_file_binary_attrs(content:, filepath:, cocina_file:)
+      end
+
+      ids = attrs.each_slice(BATCH_SIZE).flat_map do |batch|
+        ContentFileBinary.insert_all!(batch, returning: [:id]).rows.flatten # rubocop:disable Rails/SkipsModelValidations
+      end
+
+      filepaths.zip(ids).to_h
+    end
+
+    def content_file_binary_attrs(content:, filepath:, cocina_file:)
+      {
+        content_id: content.id,
+        file_location: 'deposited',
+        filepath:,
+        **filepath_attributes(filepath:),
+        **message_digest_attributes(cocina_file:),
+        size: cocina_file.size,
+        mime_type: cocina_file.hasMimeType
+      }
+    end
+
+    def build_content_files(file_set_pairs:, binary_ids_by_filepath:)
+      attrs = file_set_pairs.flat_map do |cocina_file_set, content_file_set_id|
+        Array(cocina_file_set.structural&.contains).each_with_index.map do |cocina_file, index|
+          content_file_binary_id = binary_ids_by_filepath.fetch(cocina_file.filename)
+          content_file_attrs(content_file_set_id:, content_file_binary_id:, cocina_file:, position: index + 1)
+        end
+      end
+
+      return if attrs.empty?
+
+      attrs.each_slice(BATCH_SIZE) do |batch|
+        ContentFile.insert_all!(batch) # rubocop:disable Rails/SkipsModelValidations
+      end
+    end
+
+    def content_file_attrs(content_file_set_id:, content_file_binary_id:, cocina_file:, position:)
+      {
+        content_file_set_id:,
+        content_file_binary_id:,
+        position:,
+        label: cocina_file.label,
+        external_identifier: cocina_file.externalIdentifier,
+        language_tag: cocina_file.languageTag,
+        use: cocina_file.use,
+        sdr_generated_text: cocina_file.sdrGeneratedText,
+        corrected_for_accessibility: cocina_file.correctedForAccessibility,
+        **access_attributes(cocina_file:),
+        **administrative_attributes(cocina_file:),
+        **presentation_attributes(cocina_file:)
+      }
+    end
+
+    def filepath_attributes(filepath:)
+      {
+        basename: FilenameSupport.basename(filepath:),
+        extname: FilenameSupport.extname(filepath:),
+        path_parts: FilenameSupport.path_parts(filepath:)
+      }
+    end
+
+    def message_digest_attributes(cocina_file:)
+      {
+        md5_digest: message_digest(cocina_file:, type: 'md5'),
+        sha1_digest: message_digest(cocina_file:, type: 'sha1')
+      }
+    end
+
+    def message_digest(cocina_file:, type:)
+      cocina_file.hasMessageDigests.find { |digest| digest.type == type }&.digest
+    end
+
+    def access_attributes(cocina_file:)
+      {
+        view: cocina_file.access.view,
+        download: cocina_file.access.download,
+        location: cocina_file.access.location
+      }
+    end
+
+    def administrative_attributes(cocina_file:)
+      {
+        publish: cocina_file.administrative.publish,
+        preserve: cocina_file.administrative.sdrPreserve,
+        shelve: cocina_file.administrative.shelve
+      }
+    end
+
+    def presentation_attributes(cocina_file:)
+      {
+        height: cocina_file.presentation&.height,
+        width: cocina_file.presentation&.width
+      }
+    end
+  end
+end

--- a/app/services/filename_support.rb
+++ b/app/services/filename_support.rb
@@ -1,0 +1,41 @@
+# frozen_string_literal: true
+
+# Support for working with filenames
+class FilenameSupport
+  # @return [String,nil] the path of the file or nil if no path
+  def self.path(filepath:)
+    return if filepath.nil?
+
+    if (path = File.dirname(filepath)) == '.'
+      nil
+    else
+      path
+    end
+  end
+
+  # @return [Array<String>] the parts of the path or an empty array if no path
+  def self.path_parts(filepath:)
+    path(filepath:)&.split('/') || []
+  end
+
+  # @return [String,nil] the basename of the file (e.g., "file" for "file.txt") or nil if no file
+  def self.basename(filepath:)
+    return if filepath.nil?
+
+    File.basename(filepath, '.*')
+  end
+
+  # @return [String,nil] the extension of the file (e.g., "txt" for "file.txt") or nil if no file
+  def self.extname(filepath:)
+    return if filepath.nil?
+
+    File.extname(filepath).delete_prefix('.')
+  end
+
+  # @return [String,nil] the filename of the file (e.g., "file.txt" for "dir/file.txt") or nil if no file
+  def self.filename(filepath:)
+    return if filepath.nil?
+
+    File.basename(filepath)
+  end
+end

--- a/db/migrate/20260813125637_create_content.rb
+++ b/db/migrate/20260813125637_create_content.rb
@@ -1,0 +1,12 @@
+class CreateContent < ActiveRecord::Migration[8.1]
+  def change
+    create_table :contents do |t|
+      t.string :druid, null: false
+      t.string :lock, null: false
+      t.string :staging_state, null: false, default: 'staging_not_in_progress'
+      t.boolean :immutable, null: false, default: true
+      t.timestamps
+      t.index [:druid, :lock, :immutable], unique: true
+    end
+  end
+end

--- a/db/migrate/20260813125648_create_content_file_set.rb
+++ b/db/migrate/20260813125648_create_content_file_set.rb
@@ -1,0 +1,13 @@
+class CreateContentFileSet < ActiveRecord::Migration[8.1]
+  def change
+    create_table :content_file_sets do |t|
+      t.belongs_to :content, null: false, foreign_key: true
+      t.integer :position, null: false
+      t.string :file_set_type, null: false
+      t.string :label, null: false
+      t.string :external_identifier
+      t.timestamps
+      t.index [:content_id, :position], unique: true
+    end
+  end
+end

--- a/db/migrate/20260813125650_create_content_file_binary.rb
+++ b/db/migrate/20260813125650_create_content_file_binary.rb
@@ -1,0 +1,18 @@
+class CreateContentFileBinary < ActiveRecord::Migration[8.1]
+  def change
+    create_table :content_file_binaries do |t|
+      t.belongs_to :content, null: false, foreign_key: true
+      t.string :file_location, null: false
+      t.string :filepath, null: false
+      t.string :basename, null: false
+      t.string :extname, null: false
+      t.string :path_parts, array: true, null: false, default: []
+      t.bigint :size
+      t.string :md5_digest
+      t.string :sha1_digest
+      t.string :mime_type
+      t.timestamps
+      t.index [:content_id, :filepath], unique: true
+    end
+  end
+end

--- a/db/migrate/20260813125653_create_content_file.rb
+++ b/db/migrate/20260813125653_create_content_file.rb
@@ -1,0 +1,26 @@
+class CreateContentFile < ActiveRecord::Migration[8.1]
+  def change
+    create_table :content_files do |t|
+      t.belongs_to :content_file_set, null: false, foreign_key: true
+      t.belongs_to :content_file_binary, null: false, foreign_key: true
+      t.integer :position, null: false
+      t.string :label, null: false
+      t.string :external_identifier
+      t.string :language_tag
+      t.string :use
+      t.boolean :sdr_generated_text, null: false, default: false
+      t.boolean :corrected_for_accessibility, null: false, default: false
+      t.string :view, null: false
+      t.string :download, null: false
+      t.string :location
+      t.boolean :publish, null: false
+      t.boolean :preserve, null: false
+      t.boolean :shelve, null: false
+      t.integer :height
+      t.integer :width
+      t.timestamps
+      t.index [:content_file_set_id, :position], unique: true
+      t.index [:content_file_set_id, :content_file_binary_id], unique: true
+    end
+  end
+end

--- a/db/migrate/20260814125042_create_active_storage_tables.active_storage.rb
+++ b/db/migrate/20260814125042_create_active_storage_tables.active_storage.rb
@@ -1,0 +1,57 @@
+# This migration comes from active_storage (originally 20170806125915)
+class CreateActiveStorageTables < ActiveRecord::Migration[7.0]
+  def change
+    # Use Active Record's configured type for primary and foreign keys
+    primary_key_type, foreign_key_type = primary_and_foreign_key_types
+
+    create_table :active_storage_blobs, id: primary_key_type do |t|
+      t.string   :key,          null: false
+      t.string   :filename,     null: false
+      t.string   :content_type
+      t.text     :metadata
+      t.string   :service_name, null: false
+      t.bigint   :byte_size,    null: false
+      t.string   :checksum
+
+      if connection.supports_datetime_with_precision?
+        t.datetime :created_at, precision: 6, null: false
+      else
+        t.datetime :created_at, null: false
+      end
+
+      t.index [ :key ], unique: true
+    end
+
+    create_table :active_storage_attachments, id: primary_key_type do |t|
+      t.string     :name,     null: false
+      t.references :record,   null: false, polymorphic: true, index: false, type: foreign_key_type
+      t.references :blob,     null: false, type: foreign_key_type
+
+      if connection.supports_datetime_with_precision?
+        t.datetime :created_at, precision: 6, null: false
+      else
+        t.datetime :created_at, null: false
+      end
+
+      t.index [ :record_type, :record_id, :name, :blob_id ], name: :index_active_storage_attachments_uniqueness, unique: true
+      t.foreign_key :active_storage_blobs, column: :blob_id
+    end
+
+    create_table :active_storage_variant_records, id: primary_key_type do |t|
+      t.belongs_to :blob, null: false, index: false, type: foreign_key_type
+      t.string :variation_digest, null: false
+
+      t.index [ :blob_id, :variation_digest ], name: :index_active_storage_variant_records_uniqueness, unique: true
+      t.foreign_key :active_storage_blobs, column: :blob_id
+    end
+  end
+
+  private
+    def primary_and_foreign_key_types
+      config = Rails.configuration.generators
+      setting = config.options[config.orm][:primary_key_type]
+      primary_key_type = setting || :primary_key
+      foreign_key_type = setting || :bigint
+      [ primary_key_type, foreign_key_type ]
+    end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,9 +10,37 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.1].define(version: 2026_08_09_212959) do
+ActiveRecord::Schema[8.1].define(version: 2026_08_14_125042) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pg_catalog.plpgsql"
+
+  create_table "active_storage_attachments", force: :cascade do |t|
+    t.bigint "blob_id", null: false
+    t.datetime "created_at", null: false
+    t.string "name", null: false
+    t.bigint "record_id", null: false
+    t.string "record_type", null: false
+    t.index ["blob_id"], name: "index_active_storage_attachments_on_blob_id"
+    t.index ["record_type", "record_id", "name", "blob_id"], name: "index_active_storage_attachments_uniqueness", unique: true
+  end
+
+  create_table "active_storage_blobs", force: :cascade do |t|
+    t.bigint "byte_size", null: false
+    t.string "checksum"
+    t.string "content_type"
+    t.datetime "created_at", null: false
+    t.string "filename", null: false
+    t.string "key", null: false
+    t.text "metadata"
+    t.string "service_name", null: false
+    t.index ["key"], name: "index_active_storage_blobs_on_key", unique: true
+  end
+
+  create_table "active_storage_variant_records", force: :cascade do |t|
+    t.bigint "blob_id", null: false
+    t.string "variation_digest", null: false
+    t.index ["blob_id", "variation_digest"], name: "index_active_storage_variant_records_uniqueness", unique: true
+  end
 
   create_table "bulk_actions", force: :cascade do |t|
     t.string "action_type", null: false
@@ -25,6 +53,71 @@ ActiveRecord::Schema[8.1].define(version: 2026_08_09_212959) do
     t.datetime "updated_at", null: false
     t.bigint "user_id", null: false
     t.index ["user_id"], name: "index_bulk_actions_on_user_id"
+  end
+
+  create_table "content_file_binaries", force: :cascade do |t|
+    t.string "basename", null: false
+    t.bigint "content_id", null: false
+    t.datetime "created_at", null: false
+    t.string "extname", null: false
+    t.string "file_location", null: false
+    t.string "filepath", null: false
+    t.string "md5_digest"
+    t.string "mime_type"
+    t.string "path_parts", default: [], null: false, array: true
+    t.string "sha1_digest"
+    t.bigint "size"
+    t.datetime "updated_at", null: false
+    t.index ["content_id", "filepath"], name: "index_content_file_binaries_on_content_id_and_filepath", unique: true
+    t.index ["content_id"], name: "index_content_file_binaries_on_content_id"
+  end
+
+  create_table "content_file_sets", force: :cascade do |t|
+    t.bigint "content_id", null: false
+    t.datetime "created_at", null: false
+    t.string "external_identifier"
+    t.string "file_set_type", null: false
+    t.string "label", null: false
+    t.integer "position", null: false
+    t.datetime "updated_at", null: false
+    t.index ["content_id", "position"], name: "index_content_file_sets_on_content_id_and_position", unique: true
+    t.index ["content_id"], name: "index_content_file_sets_on_content_id"
+  end
+
+  create_table "content_files", force: :cascade do |t|
+    t.bigint "content_file_binary_id", null: false
+    t.bigint "content_file_set_id", null: false
+    t.boolean "corrected_for_accessibility", default: false, null: false
+    t.datetime "created_at", null: false
+    t.string "download", null: false
+    t.string "external_identifier"
+    t.integer "height"
+    t.string "label", null: false
+    t.string "language_tag"
+    t.string "location"
+    t.integer "position", null: false
+    t.boolean "preserve", null: false
+    t.boolean "publish", null: false
+    t.boolean "sdr_generated_text", default: false, null: false
+    t.boolean "shelve", null: false
+    t.datetime "updated_at", null: false
+    t.string "use"
+    t.string "view", null: false
+    t.integer "width"
+    t.index ["content_file_binary_id"], name: "index_content_files_on_content_file_binary_id"
+    t.index ["content_file_set_id", "content_file_binary_id"], name: "idx_on_content_file_set_id_content_file_binary_id_6042d030c0", unique: true
+    t.index ["content_file_set_id", "position"], name: "index_content_files_on_content_file_set_id_and_position", unique: true
+    t.index ["content_file_set_id"], name: "index_content_files_on_content_file_set_id"
+  end
+
+  create_table "contents", force: :cascade do |t|
+    t.datetime "created_at", null: false
+    t.string "druid", null: false
+    t.boolean "immutable", default: true, null: false
+    t.string "lock", null: false
+    t.string "staging_state", default: "staging_not_in_progress", null: false
+    t.datetime "updated_at", null: false
+    t.index ["druid", "lock", "immutable"], name: "index_contents_on_druid_and_lock_and_immutable", unique: true
   end
 
   create_table "permissions", force: :cascade do |t|
@@ -46,5 +139,11 @@ ActiveRecord::Schema[8.1].define(version: 2026_08_09_212959) do
     t.index ["email_address"], name: "index_users_on_email_address", unique: true
   end
 
+  add_foreign_key "active_storage_attachments", "active_storage_blobs", column: "blob_id"
+  add_foreign_key "active_storage_variant_records", "active_storage_blobs", column: "blob_id"
   add_foreign_key "bulk_actions", "users"
+  add_foreign_key "content_file_binaries", "contents"
+  add_foreign_key "content_file_sets", "contents"
+  add_foreign_key "content_files", "content_file_binaries"
+  add_foreign_key "content_files", "content_file_sets"
 end

--- a/spec/factories/content_file_binaries.rb
+++ b/spec/factories/content_file_binaries.rb
@@ -1,0 +1,11 @@
+# frozen_string_literal: true
+
+FactoryBot.define do
+  factory :content_file_binary do
+    content
+    file_location { 'attached' }
+    filepath { 'image1.tif' }
+    basename { 'image1' }
+    extname { '.tif' }
+  end
+end

--- a/spec/factories/content_file_sets.rb
+++ b/spec/factories/content_file_sets.rb
@@ -1,0 +1,10 @@
+# frozen_string_literal: true
+
+FactoryBot.define do
+  factory :content_file_set do
+    content
+    position { 1 }
+    file_set_type { 'file' }
+    label { 'Object 1' }
+  end
+end

--- a/spec/factories/content_files.rb
+++ b/spec/factories/content_files.rb
@@ -1,0 +1,15 @@
+# frozen_string_literal: true
+
+FactoryBot.define do
+  factory :content_file do
+    content_file_set
+    content_file_binary { association :content_file_binary, content: content_file_set.content }
+    position { 1 }
+    label { 'Image 1' }
+    view { 'world' }
+    download { 'world' }
+    publish { true }
+    preserve { true }
+    shelve { true }
+  end
+end

--- a/spec/factories/contents.rb
+++ b/spec/factories/contents.rb
@@ -1,0 +1,8 @@
+# frozen_string_literal: true
+
+FactoryBot.define do
+  factory :content do
+    druid { generate(:unique_druid) }
+    lock { 'druid-version-1' }
+  end
+end

--- a/spec/models/content_file_binary_spec.rb
+++ b/spec/models/content_file_binary_spec.rb
@@ -1,0 +1,58 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe ContentFileBinary do
+  describe '#filename' do
+    subject(:content_file_binary) { build(:content_file_binary, filepath: 'folder1/folder2/image1.tif') }
+
+    it 'returns the filename portion of the filepath' do
+      expect(content_file_binary.filename).to eq('image1.tif')
+    end
+  end
+
+  describe '#set_filepath_parts' do
+    subject(:content_file_binary) { create(:content_file_binary, filepath: 'folder1/folder2/image1.tif') }
+
+    it 'derives path_parts, basename, and extname from the filepath' do
+      expect(content_file_binary.path_parts).to eq(%w[folder1 folder2])
+      expect(content_file_binary.basename).to eq('image1')
+      expect(content_file_binary.extname).to eq('tif')
+    end
+  end
+
+  describe 'deposit validation context' do
+    let(:deposit_ready_attributes) do
+      {
+        size: 12_345,
+        md5_digest: 'b6ce12a1dd5db09f10b51659c83f90a3',
+        sha1_digest: 'ff66b3b3dc3ef733d39e949549791ff78754871b',
+        mime_type: 'image/tiff',
+        file_location: 'deposited'
+      }
+    end
+
+    it 'is valid when required attributes are present and file_location is deposited or stage' do
+      expect(build(:content_file_binary, **deposit_ready_attributes)).to be_valid(:deposit)
+      expect(build(:content_file_binary, **deposit_ready_attributes, file_location: 'stage')).to be_valid(:deposit)
+    end
+
+    it 'is invalid without size, md5_digest, sha1_digest, or mime_type' do
+      content_file_binary = build(:content_file_binary, **deposit_ready_attributes,
+                                                         size: nil, md5_digest: nil, sha1_digest: nil, mime_type: nil)
+
+      expect(content_file_binary).not_to be_valid(:deposit)
+      expect(content_file_binary.errors[:size]).to include("can't be blank")
+      expect(content_file_binary.errors[:md5_digest]).to include("can't be blank")
+      expect(content_file_binary.errors[:sha1_digest]).to include("can't be blank")
+      expect(content_file_binary.errors[:mime_type]).to include("can't be blank")
+    end
+
+    it 'is invalid when file_location is not deposited or stage' do
+      content_file_binary = build(:content_file_binary, **deposit_ready_attributes, file_location: 'attached')
+
+      expect(content_file_binary).not_to be_valid(:deposit)
+      expect(content_file_binary.errors[:file_location]).to include('is not included in the list')
+    end
+  end
+end

--- a/spec/models/content_file_set_spec.rb
+++ b/spec/models/content_file_set_spec.rb
@@ -1,0 +1,19 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe ContentFileSet do
+  describe 'deposit validation context' do
+    it 'is valid with an external_identifier' do
+      expect(build(:content_file_set, external_identifier: 'https://cocina.sul.stanford.edu/fileSet/abc')).to(
+        be_valid(:deposit)
+      )
+    end
+
+    it 'is invalid without an external_identifier' do
+      content_file_set = build(:content_file_set, external_identifier: nil)
+      expect(content_file_set).not_to be_valid(:deposit)
+      expect(content_file_set.errors[:external_identifier]).to include("can't be blank")
+    end
+  end
+end

--- a/spec/models/content_file_spec.rb
+++ b/spec/models/content_file_spec.rb
@@ -1,0 +1,24 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe ContentFile do
+  describe 'deposit validation context' do
+    let(:deposit_ready_attributes) do
+      {
+        external_identifier: 'https://cocina.sul.stanford.edu/file/abc'
+      }
+    end
+
+    it 'is valid when required attributes are present' do
+      expect(build(:content_file, **deposit_ready_attributes)).to be_valid(:deposit)
+    end
+
+    it 'is invalid without external_identifier' do
+      content_file = build(:content_file, **deposit_ready_attributes, external_identifier: nil)
+
+      expect(content_file).not_to be_valid(:deposit)
+      expect(content_file.errors[:external_identifier]).to include("can't be blank")
+    end
+  end
+end

--- a/spec/services/cocina_object_mutators/structural_mutator_spec.rb
+++ b/spec/services/cocina_object_mutators/structural_mutator_spec.rb
@@ -1,0 +1,174 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe CocinaObjectMutators::StructuralMutator do
+  subject(:mutated_cocina_object) { described_class.call(cocina_object:, content:) }
+
+  let(:cocina_object) do
+    dro_with_metadata = build(:dro_with_metadata)
+    dro_with_metadata.new(access: dro_with_metadata.access.new(view: 'world', download: 'world'))
+  end
+
+  context 'when the cocina_object is not a DRO' do
+    let(:cocina_object) { build(:collection_with_metadata) }
+    let(:content) { create(:content) }
+
+    it 'raises' do
+      expect { mutated_cocina_object }.to raise_error(
+        ArgumentError, 'Expected a Cocina::Models::DRO or Cocina::Models::DROWithMetadata'
+      )
+    end
+  end
+
+  context 'with no ContentFileSets' do
+    let(:content) { create(:content) }
+
+    it 'builds an empty structural.contains' do
+      expect(mutated_cocina_object.structural.contains).to eq([])
+    end
+  end
+
+  context 'with ContentFileSets and ContentFiles' do
+    let(:content) { create(:content) }
+
+    let(:first_content_file_set) do
+      create(:content_file_set, content:, position: 1, file_set_type: 'image', label: 'Image 1',
+                                external_identifier: 'https://cocina.sul.stanford.edu/fileSet/first')
+    end
+    let(:second_content_file_set) do
+      create(:content_file_set, content:, position: 2, file_set_type: 'page', label: 'Page 1',
+                                external_identifier: 'https://cocina.sul.stanford.edu/fileSet/second')
+    end
+
+    let(:first_content_file_binary) do
+      create(:content_file_binary, content:, filepath: 'folder1/image1.tif',
+                                   size: 12_345, md5_digest: 'md5digest', sha1_digest: 'sha1digest',
+                                   mime_type: 'image/tiff', file_location: 'deposited')
+    end
+    let(:second_content_file_binary) do
+      create(:content_file_binary, content:, filepath: 'image2.tif',
+                                   size: 543, md5_digest: 'md5digest2', sha1_digest: 'sha1digest2',
+                                   mime_type: 'image/tiff', file_location: 'deposited')
+    end
+
+    before do
+      create(:content_file, content_file_set: first_content_file_set, content_file_binary: first_content_file_binary,
+                            position: 1, label: 'Image 1 file',
+                            external_identifier: 'https://cocina.sul.stanford.edu/file/first',
+                            language_tag: 'en', use: 'transcription',
+                            sdr_generated_text: true, corrected_for_accessibility: true,
+                            view: 'location-based', download: 'location-based', location: 'music',
+                            publish: true, preserve: false, shelve: true,
+                            height: 5833, width: 4001)
+      create(:content_file, content_file_set: second_content_file_set, content_file_binary: second_content_file_binary,
+                            position: 1, label: 'Page 1 file',
+                            external_identifier: 'https://cocina.sul.stanford.edu/file/second',
+                            view: 'world', download: 'world', publish: false, preserve: true, shelve: false)
+    end
+
+    it 'rebuilds structural.contains from the Content' do
+      file_sets = mutated_cocina_object.structural.contains
+      expect(file_sets.size).to eq(2)
+
+      first_file_set = file_sets.first
+      expect(first_file_set).to have_attributes(
+        type: 'https://cocina.sul.stanford.edu/models/resources/image',
+        externalIdentifier: 'https://cocina.sul.stanford.edu/fileSet/first',
+        label: 'Image 1',
+        version: cocina_object.version
+      )
+
+      first_file = first_file_set.structural.contains.sole
+      expect(first_file).to have_attributes(
+        type: Cocina::Models::ObjectType.file,
+        externalIdentifier: 'https://cocina.sul.stanford.edu/file/first',
+        label: 'Image 1 file',
+        filename: 'folder1/image1.tif',
+        version: cocina_object.version,
+        size: 12_345,
+        hasMimeType: 'image/tiff',
+        languageTag: 'en',
+        use: 'transcription',
+        sdrGeneratedText: true,
+        correctedForAccessibility: true
+      )
+      expect(first_file.hasMessageDigests).to contain_exactly(
+        Cocina::Models::MessageDigest.new(type: 'md5', digest: 'md5digest'),
+        Cocina::Models::MessageDigest.new(type: 'sha1', digest: 'sha1digest')
+      )
+      expect(first_file.access).to have_attributes(
+        view: 'location-based', download: 'location-based', location: 'music'
+      )
+      expect(first_file.administrative).to have_attributes(publish: true, sdrPreserve: false, shelve: true)
+      expect(first_file.presentation).to have_attributes(height: 5833, width: 4001)
+
+      second_file_set = file_sets.second
+      expect(second_file_set).to have_attributes(
+        type: 'https://cocina.sul.stanford.edu/models/resources/page',
+        externalIdentifier: 'https://cocina.sul.stanford.edu/fileSet/second',
+        label: 'Page 1'
+      )
+
+      second_file = second_file_set.structural.contains.sole
+      expect(second_file).to have_attributes(filename: 'image2.tif', size: 543, hasMimeType: 'image/tiff')
+      expect(second_file.presentation).to be_nil
+    end
+  end
+
+  context 'when a ContentFileSet is not valid for deposit' do
+    let(:content) { create(:content) }
+    let(:content_file_set) { create(:content_file_set, content:, external_identifier: nil) }
+
+    before do
+      create(:content_file, content_file_set:, external_identifier: 'https://cocina.sul.stanford.edu/file/first')
+    end
+
+    it 'raises' do
+      expect { mutated_cocina_object }.to raise_error(ActiveRecord::RecordInvalid, /blank/) do |error|
+        expect(error.record).to eq(content_file_set)
+      end
+    end
+  end
+
+  context 'when a ContentFile is not valid for deposit' do
+    let(:content) { create(:content) }
+    let(:content_file_set) do
+      create(:content_file_set, content:, external_identifier: 'https://cocina.sul.stanford.edu/fileSet/first')
+    end
+    let(:content_file) { create(:content_file, content_file_set:, external_identifier: nil) }
+
+    before { content_file }
+
+    it 'raises with the errors for the invalid ContentFile' do
+      expect { mutated_cocina_object }.to raise_error(ActiveRecord::RecordInvalid) do |error|
+        expect(error.record).to eq(content_file)
+        expect(error.message).to include("External identifier can't be blank")
+      end
+    end
+  end
+
+  context 'when a ContentFileBinary is not valid for deposit' do
+    let(:content) { create(:content) }
+    let(:content_file_set) do
+      create(:content_file_set, content:, external_identifier: 'https://cocina.sul.stanford.edu/fileSet/first')
+    end
+    let(:content_file_binary) { create(:content_file_binary, content:, file_location: 'attached', mime_type: nil) }
+    let(:content_file) do
+      create(:content_file, content_file_set:, content_file_binary:,
+                            external_identifier: 'https://cocina.sul.stanford.edu/file/first')
+    end
+
+    before { content_file }
+
+    it 'raises with the errors for the invalid ContentFileBinary' do
+      expect { mutated_cocina_object }.to raise_error(ActiveRecord::RecordInvalid) do |error|
+        expect(error.record).to eq(content_file_binary)
+        expect(error.message).to include(
+          "Size can't be blank", "Md5 digest can't be blank", "Sha1 digest can't be blank",
+          "Mime type can't be blank", 'File location is not included in the list'
+        )
+      end
+    end
+  end
+end

--- a/spec/services/contents/builder_spec.rb
+++ b/spec/services/contents/builder_spec.rb
@@ -1,0 +1,449 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe Contents::Builder do
+  subject(:content) { described_class.call(cocina_object:) }
+
+  let(:cocina_object) { Cocina::Models.with_metadata(Cocina::Models.build(cocina_hash), 'abc123') }
+
+  let(:druid) { 'druid:qr773tm1060' }
+
+  context 'with no file sets' do
+    let(:cocina_hash) do
+      {
+        'type' => Cocina::Models::ObjectType.image,
+        'externalIdentifier' => druid,
+        'version' => 1,
+        'access' => {
+          'view' => 'world',
+          'download' => 'world'
+        },
+        'administrative' => {
+          'hasAdminPolicy' => 'druid:fh940mz2717'
+        },
+        'description' => {
+          'title' => [
+            {
+              'value' => 'dood'
+            }
+          ],
+          'purl' => 'https://purl.stanford.edu/qr773tm1060',
+          'access' => {
+            'digitalRepository' => [
+              {
+                'value' => 'Stanford Digital Repository'
+              }
+            ]
+          }
+        },
+        'identification' => {
+          'sourceId' => 'foo:129'
+        },
+        'structural' => {}
+      }
+    end
+
+    it 'creates a Content with no ContentFileSets' do
+      expect(content).to be_a(Content)
+      expect(content).to have_attributes(druid:, lock: 'abc123', immutable: true)
+      expect(content.content_file_sets).to be_empty
+    end
+
+    context 'when immutable is false' do
+      subject(:content) { described_class.call(cocina_object:, immutable: false) }
+
+      it 'creates a Content that is not immutable' do
+        expect(content).to have_attributes(immutable: false)
+      end
+    end
+  end
+
+  context 'with file sets and files' do
+    let(:cocina_hash) do
+      {
+        'type' => Cocina::Models::ObjectType.image,
+        'externalIdentifier' => druid,
+        'version' => 1,
+        'access' => {
+          'view' => 'world',
+          'download' => 'world'
+        },
+        'administrative' => {
+          'hasAdminPolicy' => 'druid:fh940mz2717'
+        },
+        'description' => {
+          'title' => [
+            {
+              'value' => 'dood'
+            }
+          ],
+          'purl' => 'https://purl.stanford.edu/qr773tm1060',
+          'access' => {
+            'digitalRepository' => [
+              {
+                'value' => 'Stanford Digital Repository'
+              }
+            ]
+          }
+        },
+        'identification' => {
+          'sourceId' => 'foo:129'
+        },
+        'structural' => {
+          'contains' => [
+            {
+              'type' => Cocina::Models::FileSetType.image,
+              'externalIdentifier' => 'https://cocina.sul.stanford.edu/fileSet/e43590ae-abf9-4a5c-88f2-a8627969dc23',
+              'label' => 'Image 1',
+              'version' => 1,
+              'structural' => {
+                'contains' => [
+                  {
+                    'type' => Cocina::Models::ObjectType.file,
+                    'externalIdentifier' => 'https://cocina.sul.stanford.edu/file/de24d694-2fe8-41a5-9113-ae6adf4506fd',
+                    'label' => 'Image 1 file',
+                    'filename' => 'folder1/qr773tm1060_0001.tiff',
+                    'size' => 22_454_748,
+                    'version' => 1,
+                    'hasMimeType' => 'image/tiff',
+                    'use' => 'transcription',
+                    'languageTag' => 'en',
+                    'sdrGeneratedText' => true,
+                    'correctedForAccessibility' => true,
+                    'hasMessageDigests' => [
+                      {
+                        'type' => 'sha1',
+                        'digest' => 'ff66b3b3dc3ef733d39e949549791ff78754871b'
+                      },
+                      {
+                        'type' => 'md5',
+                        'digest' => 'b6ce12a1dd5db09f10b51659c83f90a3'
+                      }
+                    ],
+                    'access' => {
+                      'view' => 'location-based',
+                      'download' => 'location-based',
+                      'location' => 'music'
+                    },
+                    'administrative' => {
+                      'publish' => true,
+                      'sdrPreserve' => false,
+                      'shelve' => true
+                    },
+                    'presentation' => {
+                      'height' => 5833,
+                      'width' => 4001
+                    }
+                  }
+                ]
+              }
+            },
+            {
+              'type' => Cocina::Models::FileSetType.page,
+              'externalIdentifier' => 'https://cocina.sul.stanford.edu/fileSet/a45774e4-ac26-425a-b40e-f5e247135843',
+              'label' => 'Page 1',
+              'version' => 1,
+              'structural' => {
+                'contains' => [
+                  {
+                    'type' => Cocina::Models::ObjectType.file,
+                    'externalIdentifier' => 'https://cocina.sul.stanford.edu/file/86de37bc-b930-49ac-936b-15e8db7af88e',
+                    'label' => 'Page 1 file',
+                    'filename' => 'qr773tm1060_0002.tiff',
+                    'version' => 1,
+                    'hasMessageDigests' => [],
+                    'access' => {
+                      'view' => 'world',
+                      'download' => 'world'
+                    },
+                    'administrative' => {
+                      'publish' => false,
+                      'sdrPreserve' => true,
+                      'shelve' => false
+                    }
+                  }
+                ]
+              }
+            }
+          ]
+        }
+      }
+    end
+
+    it 'creates a Content with ContentFileSets and ContentFiles' do
+      expect(content).to have_attributes(druid:, lock: 'abc123', immutable: true)
+
+      file_sets = content.content_file_sets.sort_by(&:position)
+      expect(file_sets.size).to eq(2)
+
+      first_file_set = file_sets.first
+      expect(first_file_set).to have_attributes(
+        file_set_type: 'image',
+        label: 'Image 1',
+        external_identifier: 'https://cocina.sul.stanford.edu/fileSet/e43590ae-abf9-4a5c-88f2-a8627969dc23',
+        position: 1
+      )
+
+      first_file = first_file_set.content_files.sole
+      expect(first_file).to have_attributes(
+        position: 1,
+        file_location: 'deposited',
+        label: 'Image 1 file',
+        filepath: 'folder1/qr773tm1060_0001.tiff',
+        basename: 'qr773tm1060_0001',
+        extname: 'tiff',
+        path_parts: ['folder1'],
+        external_identifier: 'https://cocina.sul.stanford.edu/file/de24d694-2fe8-41a5-9113-ae6adf4506fd',
+        size: 22_454_748,
+        mime_type: 'image/tiff',
+        md5_digest: 'b6ce12a1dd5db09f10b51659c83f90a3',
+        sha1_digest: 'ff66b3b3dc3ef733d39e949549791ff78754871b',
+        language_tag: 'en',
+        use: 'transcription',
+        sdr_generated_text: true,
+        corrected_for_accessibility: true,
+        view: 'location-based',
+        download: 'location-based',
+        location: 'music',
+        publish: true,
+        preserve: false,
+        shelve: true,
+        height: 5833,
+        width: 4001
+      )
+
+      second_file_set = file_sets.second
+      expect(second_file_set).to have_attributes(file_set_type: 'page', label: 'Page 1', position: 2)
+
+      second_file = second_file_set.content_files.sole
+      expect(second_file).to have_attributes(
+        position: 1,
+        filepath: 'qr773tm1060_0002.tiff',
+        mime_type: nil,
+        md5_digest: nil,
+        sha1_digest: nil,
+        language_tag: nil,
+        use: nil,
+        sdr_generated_text: false,
+        corrected_for_accessibility: false,
+        view: 'world',
+        download: 'world',
+        location: nil,
+        publish: false,
+        preserve: true,
+        shelve: false,
+        height: nil,
+        width: nil
+      )
+    end
+  end
+
+  context 'with multiple files in one file set' do
+    let(:cocina_hash) do
+      {
+        'type' => Cocina::Models::ObjectType.image,
+        'externalIdentifier' => druid,
+        'version' => 1,
+        'access' => {
+          'view' => 'world',
+          'download' => 'world'
+        },
+        'administrative' => {
+          'hasAdminPolicy' => 'druid:fh940mz2717'
+        },
+        'description' => {
+          'title' => [
+            {
+              'value' => 'dood'
+            }
+          ],
+          'purl' => 'https://purl.stanford.edu/qr773tm1060',
+          'access' => {
+            'digitalRepository' => [
+              {
+                'value' => 'Stanford Digital Repository'
+              }
+            ]
+          }
+        },
+        'identification' => {
+          'sourceId' => 'foo:129'
+        },
+        'structural' => {
+          'contains' => [
+            {
+              'type' => Cocina::Models::FileSetType.image,
+              'externalIdentifier' => 'https://cocina.sul.stanford.edu/fileSet/e43590ae-abf9-4a5c-88f2-a8627969dc23',
+              'label' => 'Image 1',
+              'version' => 1,
+              'structural' => {
+                'contains' => [
+                  {
+                    'type' => Cocina::Models::ObjectType.file,
+                    'externalIdentifier' => 'https://cocina.sul.stanford.edu/file/de24d694-2fe8-41a5-9113-ae6adf4506fd',
+                    'label' => 'Image 1 file',
+                    'filename' => 'qr773tm1060_0001.tiff',
+                    'version' => 1,
+                    'hasMessageDigests' => [],
+                    'access' => {
+                      'view' => 'world',
+                      'download' => 'world'
+                    },
+                    'administrative' => {
+                      'publish' => true,
+                      'sdrPreserve' => false,
+                      'shelve' => true
+                    }
+                  },
+                  {
+                    'type' => Cocina::Models::ObjectType.file,
+                    'externalIdentifier' => 'https://cocina.sul.stanford.edu/file/86de37bc-b930-49ac-936b-15e8db7af88e',
+                    'label' => 'Image 2 file',
+                    'filename' => 'qr773tm1060_0002.tiff',
+                    'version' => 1,
+                    'hasMessageDigests' => [],
+                    'access' => {
+                      'view' => 'world',
+                      'download' => 'world'
+                    },
+                    'administrative' => {
+                      'publish' => true,
+                      'sdrPreserve' => false,
+                      'shelve' => true
+                    }
+                  }
+                ]
+              }
+            }
+          ]
+        }
+      }
+    end
+
+    it 'assigns contiguous positions to each file within the file set' do
+      file_set = content.content_file_sets.sole
+      files = file_set.content_files.sort_by(&:position)
+
+      expect(files.map(&:position)).to eq([1, 2])
+      expect(files.map(&:filepath)).to eq(['qr773tm1060_0001.tiff', 'qr773tm1060_0002.tiff'])
+    end
+  end
+
+  context 'with the same filename referenced from multiple file sets' do
+    let(:cocina_hash) do
+      {
+        'type' => Cocina::Models::ObjectType.image,
+        'externalIdentifier' => druid,
+        'version' => 1,
+        'access' => {
+          'view' => 'world',
+          'download' => 'world'
+        },
+        'administrative' => {
+          'hasAdminPolicy' => 'druid:fh940mz2717'
+        },
+        'description' => {
+          'title' => [
+            {
+              'value' => 'dood'
+            }
+          ],
+          'purl' => 'https://purl.stanford.edu/qr773tm1060',
+          'access' => {
+            'digitalRepository' => [
+              {
+                'value' => 'Stanford Digital Repository'
+              }
+            ]
+          }
+        },
+        'identification' => {
+          'sourceId' => 'foo:129'
+        },
+        'structural' => {
+          'contains' => [
+            {
+              'type' => Cocina::Models::FileSetType.image,
+              'externalIdentifier' => 'https://cocina.sul.stanford.edu/fileSet/e43590ae-abf9-4a5c-88f2-a8627969dc23',
+              'label' => 'Image 1',
+              'version' => 1,
+              'structural' => {
+                'contains' => [
+                  {
+                    'type' => Cocina::Models::ObjectType.file,
+                    'externalIdentifier' => 'https://cocina.sul.stanford.edu/file/de24d694-2fe8-41a5-9113-ae6adf4506fd',
+                    'label' => 'Image 1 file',
+                    'filename' => 'qr773tm1060_0001.tiff',
+                    'size' => 22_454_748,
+                    'version' => 1,
+                    'hasMessageDigests' => [
+                      {
+                        'type' => 'sha1',
+                        'digest' => 'ff66b3b3dc3ef733d39e949549791ff78754871b'
+                      }
+                    ],
+                    'access' => {
+                      'view' => 'world',
+                      'download' => 'world'
+                    },
+                    'administrative' => {
+                      'publish' => true,
+                      'sdrPreserve' => false,
+                      'shelve' => true
+                    }
+                  }
+                ]
+              }
+            },
+            {
+              'type' => Cocina::Models::FileSetType.page,
+              'externalIdentifier' => 'https://cocina.sul.stanford.edu/fileSet/a45774e4-ac26-425a-b40e-f5e247135843',
+              'label' => 'Page 1',
+              'version' => 1,
+              'structural' => {
+                'contains' => [
+                  {
+                    'type' => Cocina::Models::ObjectType.file,
+                    'externalIdentifier' => 'https://cocina.sul.stanford.edu/file/86de37bc-b930-49ac-936b-15e8db7af88e',
+                    'label' => 'Page 1 file',
+                    'filename' => 'qr773tm1060_0001.tiff',
+                    'size' => 22_454_748,
+                    'version' => 1,
+                    'hasMessageDigests' => [
+                      {
+                        'type' => 'sha1',
+                        'digest' => 'ff66b3b3dc3ef733d39e949549791ff78754871b'
+                      }
+                    ],
+                    'access' => {
+                      'view' => 'world',
+                      'download' => 'world'
+                    },
+                    'administrative' => {
+                      'publish' => false,
+                      'sdrPreserve' => true,
+                      'shelve' => false
+                    }
+                  }
+                ]
+              }
+            }
+          ]
+        }
+      }
+    end
+
+    it 'creates a single ContentFileBinary shared by a ContentFile in each file set' do
+      expect(content.content_file_binaries.size).to eq(1)
+
+      content_file_binary = content.content_file_binaries.sole
+      expect(content_file_binary.filepath).to eq('qr773tm1060_0001.tiff')
+
+      file_sets = content.content_file_sets.sort_by(&:position)
+      expect(file_sets.map { |file_set| file_set.content_files.sole.content_file_binary }).to all(
+        eq(content_file_binary)
+      )
+    end
+  end
+end

--- a/spec/services/filename_support_spec.rb
+++ b/spec/services/filename_support_spec.rb
@@ -1,0 +1,105 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe FilenameSupport do
+  describe '#path' do
+    context 'when nil' do
+      it 'returns nil' do
+        expect(described_class.path(filepath: nil)).to be_nil
+      end
+    end
+
+    context 'when file has no path' do
+      it 'returns nil' do
+        expect(described_class.path(filepath: 'file.txt')).to be_nil
+      end
+    end
+
+    context 'when file has a path' do
+      it 'returns the path' do
+        expect(described_class.path(filepath: 'path/to/file.txt')).to eq('path/to')
+      end
+    end
+  end
+
+  describe '#path_parts' do
+    context 'when nil' do
+      it 'returns empty array' do
+        expect(described_class.path_parts(filepath: nil)).to eq []
+      end
+    end
+
+    context 'when file has no path' do
+      it 'returns empty array' do
+        expect(described_class.path_parts(filepath: 'file.txt')).to eq []
+      end
+    end
+
+    context 'when file has a path' do
+      it 'returns the path parts' do
+        expect(described_class.path_parts(filepath: 'path/to/file.txt')).to eq %w[path to]
+      end
+    end
+  end
+
+  describe '#basename' do
+    context 'when nil' do
+      it 'returns nil' do
+        expect(described_class.basename(filepath: nil)).to be_nil
+      end
+    end
+
+    context 'when file has no path' do
+      it 'returns nil' do
+        expect(described_class.basename(filepath: 'file.txt')).to eq 'file'
+      end
+    end
+
+    context 'when file has a path' do
+      it 'returns the path' do
+        expect(described_class.basename(filepath: 'path/to/file.txt')).to eq 'file'
+      end
+    end
+  end
+
+  describe '#extname' do
+    context 'when nil' do
+      it 'returns nil' do
+        expect(described_class.extname(filepath: nil)).to be_nil
+      end
+    end
+
+    context 'when file has no path' do
+      it 'returns nil' do
+        expect(described_class.extname(filepath: 'file.txt')).to eq 'txt'
+      end
+    end
+
+    context 'when file has a path' do
+      it 'returns the path' do
+        expect(described_class.extname(filepath: 'path/to/file.txt')).to eq 'txt'
+      end
+    end
+  end
+
+  describe '#filename' do
+    context 'when nil' do
+      it 'returns nil' do
+        expect(described_class.filename(filepath: nil)).to be_nil
+      end
+    end
+
+    context 'when file has no path' do
+      it 'returns filename' do
+        expect(described_class.filename(filepath: 'file.txt')).to eq 'file.txt'
+      end
+    end
+
+    context 'when file has a path' do
+      it 'returns the path' do
+        expect(described_class.filename(filepath: 'path/to/file.txt')).to eq 'file.txt'
+      end
+    end
+  end
+end


### PR DESCRIPTION
## Summary
- Add `Content`, `ContentFileSet`, `ContentFile`, `ContentFileBinary` AR models plus their migrations (and the ActiveStorage tables migration, since `ContentFileBinary` uses `has_one_attached :file`).
- `Content` mirrors a Cocina object's structural fileSets/files; `ContentFileBinary` holds the actual attached bytes so an identical file can be shared across multiple `ContentFileSet`s via `ContentFile`.
- Add `Contents::Builder` (Cocina object → `Content`) and `CocinaObjectMutators::StructuralMutator` (`Content` → Cocina structural metadata), plus `FilenameSupport` for filepath/basename/extname parsing.
- Gemfile: `druid-tools`, `marcel` (MIME detection), `positioning` (ordering file sets/files), `state_machines-activerecord` (for `Content#staging_state`, exercised by the staging job landing in a later PR).

Part 3 of splitting up the t310-dropzone branch (see #337, #338 for parts 1–2). This is the foundational data layer the file-staging job and dropzone UI (later PRs) are built on; it ships no new routes or controllers, so it's inert until wired up.

Note: `ContentFileBinary#filepath_on_disk` references `ActiveStorageSupport`, which doesn't exist until the next PR (the staging job). That's intentional — it's not called from anywhere in this PR or exercised by this PR's specs, so it doesn't break anything; it'll be filled in when the staging job lands.

## Test plan
- [x] `RAILS_ENV=test bin/rails db:schema:load` — migrations apply cleanly on top of current `main`'s schema
- [x] `bundle exec rspec spec/models/content_file_set_spec.rb spec/models/content_file_spec.rb spec/models/content_file_binary_spec.rb spec/services/contents/builder_spec.rb spec/services/cocina_object_mutators/structural_mutator_spec.rb spec/services/filename_support_spec.rb` — 35 examples, 0 failures
- [x] `bundle exec rspec` (full suite) — 898 examples, only the 2 pre-existing failures unrelated to this change (also failing on `main`)
- [x] `bundle exec rubocop` on changed files — no offenses