### PR TITLE
Add StageFilesJob to copy attached files to SDR staging

### DIFF
--- a/app/jobs/application_job.rb
+++ b/app/jobs/application_job.rb
@@ -6,4 +6,14 @@ class ApplicationJob < ActiveJob::Base
 
   # Most jobs are safe to ignore if the underlying records are no longer available
   # discard_on ActiveJob::DeserializationError
+
+  # @param [String] title toast message to display
+  # @param [User] user recipient of the notification
+  # @param [Boolean] disappearing whether the toast auto-dismisses
+  def broadcast_toast(title:, user:, disappearing: true)
+    component = SdrViewComponents::Elements::ToastComponent.new(title:, disappearing:)
+    Turbo::StreamsChannel.broadcast_append_to('notifications', user,
+                                              target: 'toast-container',
+                                              html: ApplicationController.render(component, layout: false))
+  end
 end

--- a/app/jobs/bulk_actions/base_job.rb
+++ b/app/jobs/bulk_actions/base_job.rb
@@ -82,11 +82,7 @@ module BulkActions
     def perform_broadcast
       Turbo::StreamsChannel.broadcast_refresh_to('bulk_actions_history', bulk_action.user)
 
-      component = SdrViewComponents::Elements::ToastComponent.new(title: "#{bulk_action.label} completed",
-                                                                  disappearing: true)
-      Turbo::StreamsChannel.broadcast_append_to('notifications', bulk_action.user,
-                                                target: 'toast-container',
-                                                html: ApplicationController.render(component, layout: false))
+      broadcast_toast(title: "#{bulk_action.label} completed", user: bulk_action.user)
     end
   end
 end

--- a/app/jobs/stage_files_job.rb
+++ b/app/jobs/stage_files_job.rb
@@ -1,0 +1,76 @@
+# frozen_string_literal: true
+
+# Job that copies files to staging, generates fixities, determines mimetype,
+# updates the object, and optionally closes version.
+class StageFilesJob < ApplicationJob
+  # @param [Content] content the content whose files should be staged
+  # @param [User] user the user initiating the staging
+  # @param [Boolean] accession whether to close the version and accession after staging
+  def perform(content:, user:, accession: false) # rubocop:disable Metrics/AbcSize
+    @content = Content.with_structural_associations.find(content.id) # Pre-fetching for efficiency.
+    @user = user
+
+    check_lock! # Check cocina lock version and raise if optimistic lock problem
+    Contents::ExternalIdentifierMinter.call(content:) # Mint external identifiers for new files/filesets
+    analyze! # Generate digests, size, and mimetypes
+    stage! # Copy to staging
+    # Update SDR
+    updated_cocina_object = Sdr::Repository.update(
+      cocina_object: CocinaObjectMutators::StructuralMutator.call(cocina_object:, content:),
+      user_name: user.sunetid
+    )
+
+    content.update!(lock: updated_cocina_object.lock, immutable: true)
+
+    # Optionally start accessioning.
+    Sdr::Repository.accession(druid:, user_name: user.sunetid) if accession
+    content.staging_completed!
+
+    perform_broadcast
+  end
+
+  attr_reader :content, :user
+
+  delegate :druid, to: :content
+
+  def cocina_object
+    @cocina_object = Sdr::Repository.find(druid:)
+  end
+
+  def stageable_content_file_binaries
+    # Globus and mount to be added.
+    content.content_file_binaries.where(file_location: ['attached']).includes(file_attachment: :blob)
+  end
+
+  def check_lock!
+    return if content.lock == cocina_object.lock
+
+    raise "Lock mismatch for #{druid}. Content: #{content.lock}. Cocina object: #{cocina_object.lock}"
+  end
+
+  def analyze!
+    stageable_content_file_binaries.find_each do |content_file_binary|
+      Contents::Analyzer.call(content_file_binary:)
+    end
+  end
+
+  def stage!
+    stageable_content_file_binaries.find_each do |content_file_binary|
+      filepath = content_file_binary.filepath_on_disk
+      staging_filepath = StagingSupport.staging_filepath(druid:, filepath: content_file_binary.filepath)
+      create_directory(staging_filepath)
+      FileUtils.cp filepath, staging_filepath
+      content_file_binary.file_location_stage!
+    end
+  end
+
+  def create_directory(filepath)
+    FileUtils.mkdir_p File.dirname(filepath)
+  end
+
+  def perform_broadcast
+    Turbo::StreamsChannel.broadcast_refresh_to('objects', druid)
+
+    broadcast_toast(title: I18n.t('edit.items.new.toasts.staging_completed'), user:, disappearing: true)
+  end
+end

--- a/app/models/content.rb
+++ b/app/models/content.rb
@@ -12,6 +12,8 @@ class Content < ApplicationRecord
   has_many :content_files, through: :content_file_sets
   has_many :content_file_binaries, inverse_of: :content, dependent: :destroy
 
+  scope :with_structural_associations, -> { includes(content_file_sets: { content_files: :content_file_binary }) }
+
   state_machine :staging_state, initial: :staging_not_in_progress do
     event :staging_started do
       transition staging_not_in_progress: :staging

--- a/app/services/active_storage_support.rb
+++ b/app/services/active_storage_support.rb
@@ -1,0 +1,8 @@
+# frozen_string_literal: true
+
+# Helpers for working with ActiveStorage.
+class ActiveStorageSupport
+  def self.filepath_for_blob(blob)
+    ActiveStorage::Blob.service.path_for(blob.key)
+  end
+end

--- a/app/services/cache_support.rb
+++ b/app/services/cache_support.rb
@@ -1,0 +1,9 @@
+# frozen_string_literal: true
+
+# Helper methods for supporting caching
+class CacheSupport
+  # @return [Hash] hash for cocina object with blanks removed
+  def self.cacheable_cocina_object(cocina_object:)
+    CocinaDisplay::Utils.deep_compact_blank(cocina_object.to_h, preserve_keys: [:label])
+  end
+end

--- a/app/services/contents/analyzer.rb
+++ b/app/services/contents/analyzer.rb
@@ -1,0 +1,62 @@
+# frozen_string_literal: true
+
+module Contents
+  # Adds MD5, SHA1 and mime type to ContentFiles / ContentFileBinaries.
+  class Analyzer
+    def self.call(...)
+      new(...).call
+    end
+
+    # @param [ContentFileBinary] content_file_binary
+    def initialize(content_file_binary:)
+      @content_file_binary = content_file_binary
+    end
+
+    def call
+      update_digests!
+      update_mime_type!
+      update_size!
+      content_file_binary.save!
+    end
+
+    private
+
+    attr_reader :content_file_binary
+
+    def update_digests! # rubocop:disable Metrics/AbcSize
+      return if content_file_binary.md5_digest.present? && content_file_binary.sha1_digest.present?
+
+      md5 = Digest::MD5.new
+      sha1 = Digest::SHA1.new
+
+      File.open(content_file_binary.filepath_on_disk) do |stream|
+        while (buffer = stream.read(4096))
+          md5.update(buffer)
+          sha1.update(buffer)
+        end
+      end
+      content_file_binary.md5_digest = md5.hexdigest
+      content_file_binary.sha1_digest = sha1.hexdigest
+    end
+
+    def update_mime_type!
+      return if content_file_binary.mime_type.present?
+
+      content_file_binary.mime_type = if content_file_binary.file_location_attached?
+                                        content_file_binary.file.blob.content_type
+                                      else
+                                        Marcel::MimeType.for Pathname.new(content_file_binary.filepath_on_disk)
+                                      end
+    end
+
+    def update_size!
+      return if content_file_binary.size.present?
+
+      content_file_binary.size = if content_file_binary.file_location_attached?
+                                   content_file_binary.file.blob.byte_size
+                                 else
+                                   File.size(content_file_binary.filepath_on_disk)
+                                 end
+    end
+  end
+end

--- a/app/services/contents/external_identifier_minter.rb
+++ b/app/services/contents/external_identifier_minter.rb
@@ -1,0 +1,46 @@
+# frozen_string_literal: true
+
+module Contents
+  # Mints an external identifier for any ContentFileSet or ContentFile in a Content that is missing one, following
+  # the minting strategy in
+  # https://github.com/sul-dlss/hungry-hungry-hippo/blob/main/app/mappers/cocina/work_structural_mapper.rb
+  class ExternalIdentifierMinter
+    ID_NAMESPACE = 'https://cocina.sul.stanford.edu'
+
+    def self.call(...)
+      new(...).call
+    end
+
+    # @param [Content] content
+    def initialize(content:)
+      @content = content
+    end
+
+    def call
+      content.content_file_sets.each do |content_file_set|
+        update_file_set_identifier!(content_file_set)
+        content_file_set.content_files.each { |content_file| update_file_identifier!(content_file) }
+      end
+    end
+
+    private
+
+    attr_reader :content
+
+    def bare_druid
+      DruidSupport.bare_druid_from(content.druid)
+    end
+
+    def update_file_set_identifier!(content_file_set)
+      return if content_file_set.external_identifier.present?
+
+      content_file_set.update!(external_identifier: "#{ID_NAMESPACE}/fileSet/#{bare_druid}-#{SecureRandom.uuid}")
+    end
+
+    def update_file_identifier!(content_file)
+      return if content_file.external_identifier.present?
+
+      content_file.update!(external_identifier: "#{ID_NAMESPACE}/file/#{bare_druid}-#{SecureRandom.uuid}")
+    end
+  end
+end

--- a/app/services/staging_support.rb
+++ b/app/services/staging_support.rb
@@ -1,0 +1,13 @@
+# frozen_string_literal: true
+
+# Methods for staging support, such as constructing file paths.
+class StagingSupport
+  def self.staging_filepath(druid:, filepath:)
+    File.join(staging_content_path(druid:), filepath)
+  end
+
+  def self.staging_content_path(druid:)
+    druid_tree_folder = DruidTools::Druid.new(druid, Settings.staging_location).path
+    File.join(druid_tree_folder, 'content')
+  end
+end

--- a/config/settings.yml
+++ b/config/settings.yml
@@ -38,3 +38,8 @@ purl_fetcher:
 
 component_library:
   url: "https://cdn.jsdelivr.net/gh/sul-dlss/component-library@v2026-08-06"
+
+file_upload:
+  max_filesize: 10000 # 10GB
+
+staging_location: '/sdr-deposit-staging'

--- a/config/settings/development.yml
+++ b/config/settings/development.yml
@@ -3,3 +3,5 @@ solr:
 
 feature_flags:
   bulk_actions: true
+
+staging_location: 'tmp/sdr-deposit-staging'

--- a/config/settings/test.yml
+++ b/config/settings/test.yml
@@ -9,3 +9,5 @@ reload_intervals:
   cocina_model_stagger: 5
   bulk_actions_history: 500
   workflow_grid: 500
+
+staging_location: 'tmp/sdr-deposit-staging-test'

--- a/spec/fixtures/files/dropzone_upload.txt
+++ b/spec/fixtures/files/dropzone_upload.txt
@@ -1,0 +1,1 @@
+This is a test file for uploading via the dropzone.

--- a/spec/jobs/stage_files_job_spec.rb
+++ b/spec/jobs/stage_files_job_spec.rb
@@ -1,0 +1,131 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe StageFilesJob do
+  subject(:job) { described_class.new }
+
+  let(:druid) { 'druid:bc123df4567' }
+  let(:user) { create(:user) }
+  let(:content) { create(:content, druid:, lock: 'druid-version-1', staging_state: 'staging') }
+  let(:cocina_object) { instance_double(Cocina::Models::DROWithMetadata, lock: 'druid-version-1') }
+  let(:updated_cocina_object) { instance_double(Cocina::Models::DROWithMetadata, lock: 'druid-version-2') }
+  let(:mutated_cocina_object) { instance_double(Cocina::Models::DRO) }
+
+  let(:attached_content_file_binary) do
+    create(:content_file_binary, content:, file_location: 'attached', filepath: 'image1.tif')
+  end
+  let(:deposited_content_file_binary) do
+    create(:content_file_binary, content:, file_location: 'deposited', filepath: 'image2.tif')
+  end
+
+  let(:staging_filepath) { StagingSupport.staging_filepath(druid:, filepath: 'image1.tif') }
+
+  before do
+    attached_content_file_binary.file.attach(fixture_file_upload('dropzone_upload.txt', 'text/plain'))
+    deposited_content_file_binary
+
+    allow(Contents::ExternalIdentifierMinter).to receive(:call)
+    allow(Contents::Analyzer).to receive(:call)
+    allow(Sdr::Repository).to receive(:find).with(druid:).and_return(cocina_object)
+    allow(CocinaObjectMutators::StructuralMutator).to receive(:call)
+      .with(cocina_object:, content:).and_return(mutated_cocina_object)
+    allow(Sdr::Repository).to receive(:update)
+      .with(cocina_object: mutated_cocina_object, user_name: user.sunetid).and_return(updated_cocina_object)
+    allow(Sdr::Repository).to receive(:accession)
+    allow(Turbo::StreamsChannel).to receive(:broadcast_append_to)
+    allow(Turbo::StreamsChannel).to receive(:broadcast_refresh_to)
+  end
+
+  after do
+    FileUtils.rm_rf(StagingSupport.staging_content_path(druid:))
+  end
+
+  describe '#perform' do
+    it 'mints external identifiers for the content' do
+      job.perform(content:, user:)
+
+      expect(Contents::ExternalIdentifierMinter).to have_received(:call).with(content:)
+    end
+
+    it 'analyzes only the attached content file binaries' do
+      job.perform(content:, user:)
+
+      expect(Contents::Analyzer).to have_received(:call).with(content_file_binary: attached_content_file_binary)
+      expect(Contents::Analyzer).not_to have_received(:call).with(content_file_binary: deposited_content_file_binary)
+    end
+
+    it 'stages only the attached content file binaries' do
+      job.perform(content:, user:)
+
+      expect(File.binread(staging_filepath)).to eq(attached_content_file_binary.file.download)
+      expect(File.exist?(StagingSupport.staging_filepath(druid:, filepath: 'image2.tif'))).to be false
+    end
+
+    it 'updates the file location of staged content file binaries to stage' do
+      job.perform(content:, user:)
+
+      expect(attached_content_file_binary.reload.file_location).to eq('stage')
+      expect(deposited_content_file_binary.reload.file_location).to eq('deposited')
+    end
+
+    it 'updates SDR with the mutated structural metadata' do
+      job.perform(content:, user:)
+
+      expect(Sdr::Repository).to have_received(:update)
+        .with(cocina_object: mutated_cocina_object, user_name: user.sunetid)
+    end
+
+    it "updates the content's lock and marks it immutable" do
+      job.perform(content:, user:)
+
+      expect(content.reload).to have_attributes(lock: 'druid-version-2', immutable: true)
+    end
+
+    it 'transitions the content out of the staging state' do
+      job.perform(content:, user:)
+
+      expect(content.reload.staging_state).to eq('staging_not_in_progress')
+    end
+
+    it 'broadcasts a toast notification' do
+      job.perform(content:, user:)
+
+      expect(Turbo::StreamsChannel).to have_received(:broadcast_append_to)
+        .with('notifications', user, target: 'toast-container', html: kind_of(String))
+    end
+
+    it 'broadcasts a refresh to the object' do
+      job.perform(content:, user:)
+
+      expect(Turbo::StreamsChannel).to have_received(:broadcast_refresh_to).with('objects', druid)
+    end
+
+    it 'does not accession the object' do
+      job.perform(content:, user:)
+
+      expect(Sdr::Repository).not_to have_received(:accession)
+    end
+
+    context 'when accession is requested' do
+      it 'accessions the object' do
+        job.perform(content:, user:, accession: true)
+
+        expect(Sdr::Repository).to have_received(:accession).with(druid:, user_name: user.sunetid)
+      end
+    end
+
+    context "when the content's lock does not match the current cocina object's lock" do
+      let(:content) { create(:content, druid:, lock: 'stale-lock', staging_state: 'staging') }
+
+      it 'raises without minting identifiers, analyzing, staging, or updating SDR' do
+        expect { job.perform(content:, user:) }.to raise_error(/Lock mismatch for #{druid}/)
+
+        expect(Contents::ExternalIdentifierMinter).not_to have_received(:call)
+        expect(Contents::Analyzer).not_to have_received(:call)
+        expect(Sdr::Repository).not_to have_received(:update)
+        expect(File.exist?(staging_filepath)).to be false
+      end
+    end
+  end
+end

--- a/spec/services/contents/analyzer_spec.rb
+++ b/spec/services/contents/analyzer_spec.rb
@@ -1,0 +1,179 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe Contents::Analyzer do
+  subject(:call) { described_class.call(content_file_binary:) }
+
+  describe '#call' do
+    context 'when the digests and mime type are not yet set' do
+      let(:content_file_binary) { create(:content_file_binary, file_location: 'attached') }
+
+      before do
+        content_file_binary.file.attach(fixture_file_upload('dropzone_upload.txt', 'text/plain'))
+      end
+
+      it 'computes and persists the digests, mime type, and size' do
+        filepath_on_disk = content_file_binary.filepath_on_disk
+
+        call
+
+        expect(content_file_binary.reload).to have_attributes(
+          md5_digest: Digest::MD5.file(filepath_on_disk).hexdigest,
+          sha1_digest: Digest::SHA1.file(filepath_on_disk).hexdigest,
+          mime_type: 'text/plain',
+          size: File.size(filepath_on_disk)
+        )
+      end
+    end
+
+    context 'when the digests are already set' do
+      let(:content_file_binary) do
+        create(:content_file_binary, file_location: 'attached', md5_digest: 'existing-md5',
+                                     sha1_digest: 'existing-sha1', mime_type: 'text/plain', size: 1)
+      end
+
+      it 'does not recompute the digests' do
+        call
+
+        expect(content_file_binary).to have_attributes(md5_digest: 'existing-md5', sha1_digest: 'existing-sha1')
+      end
+    end
+
+    context 'when only one digest is set' do
+      let(:content_file_binary) { create(:content_file_binary, file_location: 'attached', md5_digest: 'stale-md5') }
+
+      before do
+        content_file_binary.file.attach(fixture_file_upload('dropzone_upload.txt', 'text/plain'))
+      end
+
+      it 'recomputes both digests from the file' do
+        filepath_on_disk = content_file_binary.filepath_on_disk
+
+        call
+
+        expect(content_file_binary).to have_attributes(
+          md5_digest: Digest::MD5.file(filepath_on_disk).hexdigest,
+          sha1_digest: Digest::SHA1.file(filepath_on_disk).hexdigest
+        )
+      end
+    end
+
+    context 'when the mime type is already set' do
+      let(:content_file_binary) do
+        create(:content_file_binary, file_location: 'attached', md5_digest: 'existing-md5',
+                                     sha1_digest: 'existing-sha1', mime_type: 'existing-mime-type', size: 1)
+      end
+
+      it 'does not recompute the mime type' do
+        call
+
+        expect(content_file_binary.mime_type).to eq('existing-mime-type')
+      end
+    end
+
+    context 'when the file location is attached' do
+      let(:content_file_binary) do
+        create(:content_file_binary, file_location: 'attached', md5_digest: 'existing-md5',
+                                     sha1_digest: 'existing-sha1')
+      end
+
+      before do
+        # identify: false keeps the declared content type instead of letting ActiveStorage sniff it,
+        # so this test can prove the blob's content type (not the file contents) drives the result.
+        content_file_binary.file.attach(
+          io: Rails.root.join('spec/fixtures/files/dropzone_upload.txt').open,
+          filename: 'dropzone_upload.txt',
+          content_type: 'application/octet-stream',
+          identify: false
+        )
+      end
+
+      it "uses the attached blob's content type" do
+        call
+
+        expect(content_file_binary.mime_type).to eq('application/octet-stream')
+      end
+    end
+
+    context 'when the file location is not attached' do
+      let(:content_file_binary) do
+        create(:content_file_binary, file_location: 'deposited', md5_digest: 'existing-md5',
+                                     sha1_digest: 'existing-sha1')
+      end
+
+      before do
+        content_file_binary.file.attach(
+          io: Rails.root.join('spec/fixtures/files/catalog_record_id_and_barcode.xlsx').open,
+          filename: 'catalog_record_id_and_barcode.xlsx',
+          content_type: 'application/octet-stream',
+          identify: false
+        )
+      end
+
+      it 'sniffs the mime type from the file contents on disk instead of using the (unset) blob content type' do
+        call
+
+        expect(content_file_binary.mime_type).to eq('application/vnd.openxmlformats-officedocument.spreadsheetml.sheet')
+      end
+    end
+
+    context 'when the size is not yet set' do
+      let(:content_file_binary) do
+        create(:content_file_binary, file_location: 'attached', md5_digest: 'existing-md5',
+                                     sha1_digest: 'existing-sha1', mime_type: 'text/plain')
+      end
+
+      before do
+        content_file_binary.file.attach(fixture_file_upload('dropzone_upload.txt', 'text/plain'))
+      end
+
+      it "uses the attached blob's byte size" do
+        call
+
+        expect(content_file_binary.size).to eq(content_file_binary.file.blob.byte_size)
+      end
+    end
+
+    context 'when the size is already set' do
+      let(:content_file_binary) do
+        create(:content_file_binary, file_location: 'attached', md5_digest: 'existing-md5',
+                                     sha1_digest: 'existing-sha1', mime_type: 'text/plain', size: 12_345)
+      end
+
+      before do
+        content_file_binary.file.attach(fixture_file_upload('dropzone_upload.txt', 'text/plain'))
+      end
+
+      it 'does not recompute the size' do
+        call
+
+        expect(content_file_binary.size).to eq(12_345)
+      end
+    end
+
+    context 'when the file location is not attached and the size is not yet set' do
+      let(:content_file_binary) do
+        create(:content_file_binary, file_location: 'deposited', md5_digest: 'existing-md5',
+                                     sha1_digest: 'existing-sha1', mime_type: 'text/plain')
+      end
+
+      before do
+        content_file_binary.file.attach(
+          io: Rails.root.join('spec/fixtures/files/catalog_record_id_and_barcode.xlsx').open,
+          filename: 'catalog_record_id_and_barcode.xlsx',
+          content_type: 'application/octet-stream',
+          identify: false
+        )
+      end
+
+      it 'reads the size from the file on disk instead of using the blob byte size' do
+        filepath_on_disk = content_file_binary.filepath_on_disk
+
+        call
+
+        expect(content_file_binary.size).to eq(File.size(filepath_on_disk))
+      end
+    end
+  end
+end

--- a/spec/services/contents/external_identifier_minter_spec.rb
+++ b/spec/services/contents/external_identifier_minter_spec.rb
@@ -1,0 +1,85 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe Contents::ExternalIdentifierMinter do
+  subject(:call) { described_class.call(content:) }
+
+  let(:content) { create(:content, druid: 'druid:bc123df4567') }
+
+  describe '#call' do
+    context 'when the file set and file are missing external identifiers' do
+      let(:content_file_set) { create(:content_file_set, content:, external_identifier: nil) }
+      let(:content_file) { create(:content_file, content_file_set:, external_identifier: nil) }
+
+      before { content_file }
+
+      it 'mints external identifiers for both' do
+        call
+
+        expect(content_file_set.reload.external_identifier).to match(
+          %r{\Ahttps://cocina\.sul\.stanford\.edu/fileSet/bc123df4567-[0-9a-f-]{36}\z}
+        )
+        expect(content_file.reload.external_identifier).to match(
+          %r{\Ahttps://cocina\.sul\.stanford\.edu/file/bc123df4567-[0-9a-f-]{36}\z}
+        )
+      end
+    end
+
+    context 'when the file set already has an external identifier' do
+      let(:content_file_set) do
+        create(:content_file_set, content:, external_identifier: 'https://cocina.sul.stanford.edu/fileSet/existing')
+      end
+
+      before { create(:content_file, content_file_set:, external_identifier: nil) }
+
+      it 'does not change the file set external identifier' do
+        call
+
+        expect(content_file_set.reload.external_identifier).to eq('https://cocina.sul.stanford.edu/fileSet/existing')
+      end
+    end
+
+    context 'when the file already has an external identifier' do
+      let(:content_file_set) { create(:content_file_set, content:, external_identifier: nil) }
+      let(:content_file) do
+        create(:content_file, content_file_set:, external_identifier: 'https://cocina.sul.stanford.edu/file/existing')
+      end
+
+      before { content_file }
+
+      it 'does not change the file external identifier' do
+        call
+
+        expect(content_file.reload.external_identifier).to eq('https://cocina.sul.stanford.edu/file/existing')
+      end
+    end
+
+    context 'when there are multiple file sets and files' do
+      let(:first_content_file_set) { create(:content_file_set, content:, position: 1, external_identifier: nil) }
+      let(:second_content_file_set) { create(:content_file_set, content:, position: 2, external_identifier: nil) }
+
+      before do
+        create(:content_file, content_file_set: first_content_file_set, position: 1, external_identifier: nil,
+                              content_file_binary: create(:content_file_binary, content:, filepath: 'image1.tif'))
+        create(:content_file, content_file_set: first_content_file_set, position: 2, external_identifier: nil,
+                              content_file_binary: create(:content_file_binary, content:, filepath: 'image2.tif'))
+        create(:content_file, content_file_set: second_content_file_set, position: 1, external_identifier: nil,
+                              content_file_binary: create(:content_file_binary, content:, filepath: 'image3.tif'))
+      end
+
+      it 'mints a distinct external identifier for each file set and file' do
+        call
+
+        external_identifiers = [
+          first_content_file_set.reload.external_identifier,
+          second_content_file_set.reload.external_identifier,
+          *first_content_file_set.content_files.map { |content_file| content_file.reload.external_identifier },
+          *second_content_file_set.content_files.map { |content_file| content_file.reload.external_identifier }
+        ]
+
+        expect(external_identifiers.uniq.size).to eq(external_identifiers.size)
+      end
+    end
+  end
+end


### PR DESCRIPTION
## Summary
- Add `StageFilesJob`: mints external identifiers for new file sets/files (`Contents::ExternalIdentifierMinter`), analyzes attached binaries for digest/size/mimetype (`Contents::Analyzer`), copies them to the staging location (`StagingSupport`), and updates the object's structural metadata in SDR — optionally closing the version and accessioning.
- Add `ActiveStorageSupport` (resolves an on-disk filepath for an ActiveStorage blob) and `CacheSupport` (small Cocina-object-to-cacheable-hash helper, used by controllers landing in a later PR).
- Extract `ApplicationJob#broadcast_toast` out of `BulkActions::BaseJob` so `StageFilesJob` can reuse the same toast-notification broadcast.
- `config/settings.yml`/`development.yml`/`test.yml`: add `staging_location` (per-environment) and `file_upload.max_filesize` (used by the dropzone UI landing in a later PR).

Part 4 of splitting up the t310-dropzone branch (see #337, #338, #339 for parts 1–3). Based on #339 (Content data model) since this job operates on those models — please review/merge #339 first; this PR's diff is scoped to just the staging job. Has no UI — the job is fully covered by its own spec.

## Test plan
- [x] `bundle exec rspec spec/jobs/stage_files_job_spec.rb spec/services/contents/analyzer_spec.rb spec/services/contents/external_identifier_minter_spec.rb` — 25 examples, 0 failures
- [x] `bundle exec rspec` (full suite) — 923 examples, only the 2 pre-existing failures unrelated to this change (also failing on `main`)
- [x] `bundle exec rubocop` on changed files — no offenses