### PR TITLE
Wire item registration and object show into file management

### DIFF
--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -2,6 +2,11 @@
 
 # Controller for items (DRO)
 class ItemsController < ApplicationController
+  # Values for submit buttons
+  DEPOSIT_VALUE = 'deposit'
+  DRAFT_VALUE = 'draft'
+  DRAFT_TO_ADD_FILES_VALUE = 'add_files'
+
   def new
     authorize! with: ItemPolicy
 
@@ -17,11 +22,23 @@ class ItemsController < ApplicationController
     if @item_form.valid?
       @item_form.create!(user_name: current_user.sunetid)
       flash[:toast] = t('edit.items.new.toasts.register')
-      redirect_to object_path(@item_form.druid)
+      redirect_to create_redirect_path
     else
       set_apo_options
       render :new, status: :unprocessable_content
     end
+  end
+
+  def update
+    druid = params[:id]
+    cocina_object = Sdr::Repository.find(druid:)
+    authorize! cocina_object, with: ItemPolicy
+
+    content = find_content(cocina_object:)
+    content.staging_started!
+    StageFilesJob.perform_later(content:, accession: params[:commit] == DEPOSIT_VALUE, user: current_user)
+    flash[:toast] = t('edit.items.new.toasts.staging_started')
+    redirect_to object_path(druid)
   end
 
   private
@@ -34,5 +51,19 @@ class ItemsController < ApplicationController
 
   def set_apo_options
     @apo_options = Searchers::AdminPolicyList.call
+  end
+
+  def create_redirect_path
+    if params[:commit] == DRAFT_TO_ADD_FILES_VALUE
+      edit_content_path(@item_form.druid)
+    else
+      object_path(@item_form.druid)
+    end
+  end
+
+  def find_content(cocina_object:)
+    Content.find_by(druid: cocina_object.externalIdentifier,
+                    lock: cocina_object.lock,
+                    immutable: false)
   end
 end

--- a/app/controllers/objects_controller.rb
+++ b/app/controllers/objects_controller.rb
@@ -3,7 +3,7 @@
 # Controller for objects (DRO, collection, admin policy)
 class ObjectsController < ApplicationController
   skip_verify_authorized only: %i[show_json show_workflows show_overview show_header show_versions
-                                  show_purl_preview show_solr_doc]
+                                  show_purl_preview show_solr_doc show_files]
 
   include TokenConcern
 
@@ -78,6 +78,12 @@ class ObjectsController < ApplicationController
     render layout: false
   end
 
+  def show_files
+    @content = fetch_content(verified_druid)
+
+    render layout: false
+  end
+
   private
 
   def verified_druid
@@ -95,7 +101,7 @@ class ObjectsController < ApplicationController
     cache_key = "objects/cocina-hash/#{druid}"
     Rails.cache.fetch(cache_key, expires_in: 10.seconds) do
       cocina_object = Sdr::Repository.find(druid:)
-      CocinaDisplay::Utils.deep_compact_blank(cocina_object.to_h, preserve_keys: [:label])
+      CacheSupport.cacheable_cocina_object(cocina_object:)
     end
   end
 
@@ -108,5 +114,11 @@ class ObjectsController < ApplicationController
   rescue PurlPreviewService::Error => e
     Honeybadger.notify(e, context: { cocina_hash: })
     nil
+  end
+
+  def fetch_content(druid)
+    cocina_object = CocinaSupport.build_from_cocina_hash(fetch_cocina_hash(druid))
+    Content.find_by(druid:, lock: cocina_object.lock, immutable: true) ||
+      Contents::Builder.call(cocina_object:)
   end
 end

--- a/app/views/contents/edit.html.erb
+++ b/app/views/contents/edit.html.erb
@@ -10,6 +10,7 @@
   <%= render SdrViewComponents::TabForm::TabListComponent.new(id: form_id, active_tab_name: :add_files) do |tab_list| %>
     <% tab_list.with_tab(label: t('edit.contents.tabs.add_files.label'), tab_name: :add_files) %>
     <% tab_list.with_tab(label: t('edit.contents.tabs.manage_files.label'), tab_name: :manage_files) %>
+    <% tab_list.with_tab(label: t('edit.contents.tabs.deposit.label'), tab_name: :deposit, mark_required: true) %>
 
     <% tab_list.with_pane(SdrViewComponents::TabForm::PaneComponent.new(tab_name: :add_files,
                                                                         label: t('edit.contents.tabs.add_files.label'))) do %>
@@ -42,6 +43,17 @@
       <%= turbo_frame_tag @content, 'show', src: content_path(@content_token), data: { controller: 'dropzone-files' }, class: 'dropzone-files' do %>
         <%= render SdrViewComponents::Elements::SpinnerComponent.new %>
       <% end %>
+    <% end %>
+
+    <% tab_list.with_pane(SdrViewComponents::TabForm::PaneComponent.new(tab_name: :deposit,
+                                                                        label: t('edit.contents.tabs.deposit.label'),
+                                                                        mark_required: true)) do %>
+      <div class="d-flex justify-content-end">
+        <%= form_with url: item_path(@content.druid), method: :patch do %>
+          <%= render SdrViewComponents::Forms::SubmitComponent.new(label: t('edit.contents.edit.buttons.draft'), value: ItemsController::DRAFT_VALUE, variant: 'outline-primary', classes: 'me-2') %>
+          <%= render SdrViewComponents::Forms::SubmitComponent.new(label: t('edit.contents.edit.buttons.deposit'), value: ItemsController::DEPOSIT_VALUE) %>
+        <% end %>
+      </div>
     <% end %>
 
   <% end %>

--- a/app/views/items/new.html.erb
+++ b/app/views/items/new.html.erb
@@ -53,8 +53,15 @@
                                                                           mark_required: true)) do %>
         <div class="d-flex justify-content-end">
           <%= render SdrViewComponents::Forms::SubmitComponent.new(
+                label: t('edit.items.new.buttons.register_add_files'),
+                form_id: form.id,
+                value: ItemsController::DRAFT_TO_ADD_FILES_VALUE,
+                classes: 'me-2'
+              ) %>
+          <%= render SdrViewComponents::Forms::SubmitComponent.new(
                 label: t('edit.items.new.buttons.register'),
                 form_id: form.id,
+                value: ItemsController::DRAFT_VALUE,
                 variant: 'outline-primary'
               ) %>
         </div>

--- a/app/views/objects/show.html.erb
+++ b/app/views/objects/show.html.erb
@@ -3,6 +3,8 @@
   <meta name="turbo-refresh-scroll" content="preserve">
 <% end %>
 
+<%= turbo_stream_from 'objects', @solr_doc.druid %>
+
 <%= tag.div class: "container object-show #{@solr_doc.object_type_class} mb-4", data: {
       controller: 'cocina-model-show',
       cocina_model_show_interval_value: Settings.reload_intervals.cocina_model,
@@ -113,7 +115,9 @@
 
         <% if @solr_doc.dro? %>
           <%= component.with_pane(id: 'files-pane', tab_id: 'files-tab') do %>
-            <p>Not implemented yet</p>
+            <%= turbo_frame_tag(@solr_doc.druid, 'files', src: files_object_path(druid: @druid_token), refresh: 'morph', target: '_top') do %>
+              <%= render SdrViewComponents::Elements::SpinnerComponent.new %>
+            <% end %>
           <% end %>
         <% end %>
 

--- a/app/views/objects/show_files.html.erb
+++ b/app/views/objects/show_files.html.erb
@@ -1,0 +1,7 @@
+<%= turbo_frame_tag(@content.druid, 'files') do %>
+  <ul>
+    <% @content.content_file_binaries.each do |content_file_binary| %>
+      <li><%= content_file_binary.filepath %></li>
+    <% end %>
+  </ul>
+<% end %>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -62,18 +62,26 @@ en:
     contents:
       edit:
         title: "Manage files"
+        buttons:
+          deposit: "Deposit"
+          draft: "Save as draft"
       tabs:
         add_files:
           label: "Add files"
         manage_files:
           label: "Manage files"
+        deposit:
+          label: "Deposit"
     items:
       new:
         title: "Register an item"
         buttons:
           register: 'Register only'
+          register_add_files: 'Register and add files'
         toasts:
           register: 'Item registered.'
+          staging_started: 'Staging started'
+          staging_completed: 'Staging completed'
       tabs:
         deposit: 
           label: "Register"

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -168,10 +168,11 @@ Rails.application.routes.draw do
       get 'versions', to: 'objects#show_versions'
       get 'purl_preview', to: 'objects#show_purl_preview'
       get 'solr_doc', to: 'objects#show_solr_doc'
+      get 'files', to: 'objects#show_files'
     end
   end
 
-  resources :items, only: %i[new create]
+  resources :items, only: %i[new create update]
 
   resources :contents, only: %i[edit update show]
 

--- a/spec/requests/show/show_files_spec.rb
+++ b/spec/requests/show/show_files_spec.rb
@@ -1,0 +1,95 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe 'Show files' do
+  let(:druid) { 'druid:bc123df4567' }
+  let(:token) do
+    Rails.application.message_verifier(:argo).generate(druid, purpose: 'show', expires_at: 1.week.from_now.end_of_day)
+  end
+  let(:invalid_token) { 'not-a-valid-token' }
+  let(:cocina_object) { Cocina::Models.with_metadata(Cocina::Models.build(cocina_hash), 'abc123') }
+  let(:cocina_hash) do
+    {
+      type: Cocina::Models::ObjectType.image,
+      externalIdentifier: druid,
+      version: 1,
+      access: {
+        view: 'world',
+        download: 'world'
+      },
+      administrative: {
+        hasAdminPolicy: 'druid:fh940mz2717'
+      },
+      description: {
+        title: [
+          {
+            value: 'Show files test object'
+          }
+        ],
+        purl: 'https://purl.stanford.edu/bc123df4567',
+        access: {
+          digitalRepository: [
+            {
+              value: 'Stanford Digital Repository'
+            }
+          ]
+        }
+      },
+      identification: {
+        sourceId: 'foo:129'
+      },
+      structural: {
+        contains: [
+          {
+            type: Cocina::Models::FileSetType.image,
+            externalIdentifier: 'https://cocina.sul.stanford.edu/fileSet/e43590ae-abf9-4a5c-88f2-a8627969dc23',
+            label: 'Image 1',
+            version: 1,
+            structural: {
+              contains: [
+                {
+                  type: Cocina::Models::ObjectType.file,
+                  externalIdentifier: 'https://cocina.sul.stanford.edu/file/de24d694-2fe8-41a5-9113-ae6adf4506fd',
+                  label: 'Image 1 file',
+                  filename: 'folder1/bc123df4567_0001.tiff',
+                  version: 1,
+                  hasMessageDigests: [],
+                  access: {
+                    view: 'world',
+                    download: 'world'
+                  },
+                  administrative: {
+                    publish: true,
+                    sdrPreserve: true,
+                    shelve: true
+                  }
+                }
+              ]
+            }
+          }
+        ]
+      }
+    }
+  end
+
+  before do
+    sign_in(create(:user))
+    allow(Sdr::Repository).to receive(:find).with(druid:).and_return(cocina_object)
+  end
+
+  describe 'GET /objects/:druid/files' do
+    it 'renders the list of file paths' do
+      get "/objects/#{token}/files"
+
+      expect(response).to have_http_status(:ok)
+      expect(response.body).to include('folder1/bc123df4567_0001.tiff')
+    end
+
+    it 'raises when token verification fails' do
+      get "/objects/#{invalid_token}/files"
+
+      expect(response).to have_http_status(:forbidden)
+    end
+  end
+end

--- a/spec/system/create_item_spec.rb
+++ b/spec/system/create_item_spec.rb
@@ -72,6 +72,25 @@ RSpec.describe 'Create an item' do
       expect(Sdr::Repository).to have_received(:create_release_tag)
         .with(druid:, user_name: user.sunetid, release_target: 'Searchworks', release: true)
     end
+
+    it 'registers and redirects to add files' do
+      visit new_item_path
+
+      fill_in 'Source ID', with: 'new:source-id'
+      fill_in 'Title', with: 'The Title'
+
+      find_by_id('rights-tab').click
+      select apo_title, from: 'APO'
+
+      find_by_id('deposit-tab').click
+      click_button('Register and add files')
+
+      expect(page).to have_current_path(edit_content_path(druid))
+      expect(page).to have_toast('Item registered.')
+
+      expect(Sdr::Repository).to have_received(:register)
+      expect(Sdr::Repository).not_to have_received(:accession)
+    end
   end
 
   context 'when invalid' do

--- a/spec/system/manage_files_spec.rb
+++ b/spec/system/manage_files_spec.rb
@@ -9,20 +9,33 @@ RSpec.describe 'Manage files' do
   let(:cocina_object) { build(:dro_with_metadata, id: druid) }
   let!(:user) { create(:user) }
 
+  let(:object_client) do
+    instance_double(Dor::Services::Client::Object, version: version_client, milestones: milestones_client,
+                                                   user_version: user_version_client)
+  end
+  let(:version_client) { instance_double(Dor::Services::Client::ObjectVersion, inventory: []) }
+  let(:user_version_client) { instance_double(Dor::Services::Client::UserVersion, inventory: []) }
+  let(:milestones_client) { instance_double(Dor::Services::Client::Milestones, list: []) }
+
   before do
     sign_in(user)
 
     allow(Sdr::Repository).to receive_messages(find: cocina_object,
                                                find_solr: build(:solr_item, druid:, title:))
+    allow(StageFilesJob).to receive(:perform_later)
+    allow(Sdr::WorkflowService).to receive(:workflows_for).and_return([])
+    allow(PurlPreviewService).to receive(:call).and_return('<html><body><main></main></body></html>')
+    allow(Dor::Services::Client).to receive(:object).with(druid).and_return(object_client)
   end
 
-  it 'displays the object title and tabs, and uploads a file' do
+  it 'displays the object title and all tabs, uploads a file, and deposits' do
     visit "/contents/#{druid}/edit"
 
     expect(page).to have_css('p', text: title)
 
     expect(page).to have_css('.nav-link', text: 'Add files')
     expect(page).to have_css('.nav-link', text: 'Manage files')
+    expect(page).to have_css('.nav-link', text: 'Deposit')
 
     attach_file(nil, Rails.root.join('spec/fixtures/files/dropzone_upload.txt'), make_visible: true)
 
@@ -39,5 +52,12 @@ RSpec.describe 'Manage files' do
     expect(content_file_binary).to have_attributes(filepath: 'dropzone_upload.txt', file_location: 'attached')
     expect(content_file_binary.file).to be_attached
     expect(content_file_binary.file.filename.to_s).to eq('dropzone_upload.txt')
+
+    click_on 'Deposit'
+    click_button('Deposit')
+
+    expect(page).to have_current_path("/objects/#{druid}")
+
+    expect(StageFilesJob).to have_received(:perform_later).with(content:, accession: true, user:)
   end
 end

--- a/spec/system/show_dro_spec.rb
+++ b/spec/system/show_dro_spec.rb
@@ -78,9 +78,36 @@ RSpec.describe 'Show DRO' do
   end
 
   def build_cocina_object(title:, access: {})
+    file_access = { view: access.fetch(:view, 'dark'), download: access.fetch(:download, 'none') }
+    file_shelve = file_access[:view] != 'dark'
+
     build(:dro_with_metadata, id: druid, admin_policy_id: apo_druid)
       .new(
-        structural: { isMemberOf: [collection_druid] },
+        structural: {
+          isMemberOf: [collection_druid],
+          contains: [
+            {
+              type: Cocina::Models::FileSetType.file,
+              externalIdentifier: 'https://cocina.sul.stanford.edu/fileSet/1',
+              label: 'Object 1',
+              version: 1,
+              structural: {
+                contains: [
+                  {
+                    type: Cocina::Models::ObjectType.file,
+                    externalIdentifier: 'https://cocina.sul.stanford.edu/file/1',
+                    label: 'File 1',
+                    filename: 'rr624wq8610_00_0001.jp2',
+                    version: 1,
+                    hasMessageDigests: [],
+                    access: file_access,
+                    administrative: { publish: true, sdrPreserve: true, shelve: file_shelve }
+                  }
+                ]
+              }
+            }
+          ]
+        },
         description: {
           title: [{ value: title }],
           purl: 'https://purl.stanford.edu/bb123cd4567'
@@ -279,6 +306,10 @@ RSpec.describe 'Show DRO' do
     expect(cells[2]).to have_text('March 31, 2021 01:23 PM')
     expect(cells[3]).to have_text('March 31, 2021 01:23 PM')
     expect(cells[4]).to have_text('March 31, 2021 02:02 PM')
+
+    # Files tab
+    click_button 'Files'
+    expect(page).to have_css('li', text: 'rr624wq8610_00_0001.jp2')
 
     # PURL preview tab
     click_button 'Description Preview'


### PR DESCRIPTION
## Summary
- `ItemsController#update`: stages the current draft's attached files via `StageFilesJob` (optionally accessioning), transitioning `Content#staging_state`, and redirects back to the object.
- `ItemsController#create`: "Register and add files" now redirects to the new manage-files page (`edit_content_path`) instead of the object page.
- `ObjectsController#show_files` + `objects/show_files.html.erb`: renders a `Content`'s attached files; the object show page's "Files" tab loads it via a Turbo frame (replacing the "Not implemented yet" placeholder) and the page now subscribes to Turbo Streams for `StageFilesJob`'s completion broadcast.
- Restores the "Deposit" tab (and its locale keys) to `contents/edit.html.erb` — this was deferred from the previous PR (#341) because it depends on `ItemsController#update`/`DEPOSIT_VALUE`/`DRAFT_VALUE`, which land here.

Part 6 (final) of splitting up the t310-dropzone branch (see #337–#341 for parts 1–5). Based on #341 since the Deposit tab restoration touches the same view.

## Test plan
- [x] `bundle exec rspec spec/system/manage_files_spec.rb spec/system/create_item_spec.rb spec/requests/show/show_files_spec.rb spec/system/show_dro_spec.rb` — 7 examples, 0 failures
- [x] `bundle exec rspec` (full suite) — 929 examples, only the 2 pre-existing failures unrelated to this change (also failing on `main`); one additional failure in `item_search_spec.rb` was a chromedriver crash under load, confirmed passing in isolation
- [x] `bundle exec rubocop` on changed files — no offenses
- [x] `npx standard` / `npx stylelint` — no offenses