### PR TITLE
add purl link to pages

### DIFF
--- a/app/helpers/link_helper.rb
+++ b/app/helpers/link_helper.rb
@@ -9,4 +9,8 @@ module LinkHelper
   def link_to_old_argo(label, druid, *, data: {}, **, &)
     link_to_new_tab(label, "#{Settings.argo.url}/view/#{druid}", *, data:, **, &)
   end
+
+  def link_to_purl(druid, *, data: {}, **, &)
+    link_to_new_tab('View PURL page', Cocina::Models::Mapping::Purl.for(druid:), *, data:, **, &)
+  end
 end

--- a/app/presenters/solr_doc_presenter.rb
+++ b/app/presenters/solr_doc_presenter.rb
@@ -42,8 +42,8 @@ class SolrDocPresenter < SearchResults::Item
     !collection? && !admin_policy? && !agreement?
   end
 
-  # items with a purl page
-  def purl?
+  # items with a purl page/description overviews
+  def dro_or_collection?
     dro? || collection?
   end
 end

--- a/app/presenters/solr_doc_presenter.rb
+++ b/app/presenters/solr_doc_presenter.rb
@@ -30,7 +30,20 @@ class SolrDocPresenter < SearchResults::Item
     object_type == 'adminPolicy'
   end
 
+  def agreement?
+    object_type == 'agreement'
+  end
+
+  def virtual_object?
+    object_type == 'virtual object'
+  end
+
   def dro?
-    !collection? && !admin_policy?
+    !collection? && !admin_policy? && !agreement?
+  end
+
+  # items with a purl page
+  def purl?
+    dro? || collection?
   end
 end

--- a/app/views/objects/show.html.erb
+++ b/app/views/objects/show.html.erb
@@ -30,7 +30,7 @@
         <%= render ThumbnailComponent.new(result: @solr_doc, dimension: 160, classes: 'mb-4') %>
       </div>
 
-      <% if @solr_doc.purl? %>
+      <% if @solr_doc.dro_or_collection? %>
         <p><%= link_to_purl(@solr_doc.druid) %></p>
       <% end %>
       <%= render Elements::ButtonListComponent.new(title: 'Actions', help_text: '(does not require new version)') do |component| %>
@@ -82,7 +82,7 @@
 
       <%= render SdrViewComponents::Elements::Tabs::TabListComponent.new(classes: 'mb-xl-3 my-4 my-xl-0', content_classes: 'mt-4', variant: :underline, collapse_below: :xl) do |component| %>
         <% component.with_tab(id: 'overview-tab', pane_id: 'overview-pane', label: 'Overview', active: true) %>
-        <% component.with_tab(id: 'purl-preview-tab', pane_id: 'purl-preview-pane', label: 'Description Preview') if @solr_doc.purl? %>
+        <% component.with_tab(id: 'purl-preview-tab', pane_id: 'purl-preview-pane', label: 'Description Preview') if @solr_doc.dro_or_collection? %>
         <% component.with_tab(id: 'files-tab', pane_id: 'files-pane', label: 'Files') if @solr_doc.dro? %>
         <% component.with_tab(id: 'workflows-tab', pane_id: 'workflows-pane', label: 'Workflows') %>
         <% component.with_tab(id: 'versions-tab', pane_id: 'versions-pane', label: 'Versions') %>
@@ -97,7 +97,7 @@
           <% end %>
         <% end %>
 
-        <% if @solr_doc.purl? %>
+        <% if @solr_doc.dro_or_collection? %>
           <%= component.with_pane(id: 'purl-preview-pane', tab_id: 'purl-preview-tab') do %>
             <%= turbo_frame_tag(@solr_doc.druid, 'purl_preview', src: purl_preview_object_path(druid: @druid_token), refresh: 'morph', target: '_top') do %>
               <%= render SdrViewComponents::Elements::SpinnerComponent.new %>

--- a/app/views/objects/show.html.erb
+++ b/app/views/objects/show.html.erb
@@ -30,6 +30,9 @@
         <%= render ThumbnailComponent.new(result: @solr_doc, dimension: 160, classes: 'mb-4') %>
       </div>
 
+      <% if @solr_doc.purl? %>
+        <p><%= link_to_purl(@solr_doc.druid) %></p>
+      <% end %>
       <%= render Elements::ButtonListComponent.new(title: 'Actions', help_text: '(does not require new version)') do |component| %>
         <% component.with_button(link: '/', label: 'Reindex', variant: 'outline-primary disabled') %>
         <% component.with_button(link: '/', label: 'Republish', variant: 'outline-primary disabled') %>
@@ -79,7 +82,7 @@
 
       <%= render SdrViewComponents::Elements::Tabs::TabListComponent.new(classes: 'mb-xl-3 my-4 my-xl-0', content_classes: 'mt-4', variant: :underline, collapse_below: :xl) do |component| %>
         <% component.with_tab(id: 'overview-tab', pane_id: 'overview-pane', label: 'Overview', active: true) %>
-        <% component.with_tab(id: 'purl-preview-tab', pane_id: 'purl-preview-pane', label: 'Description Preview') if @solr_doc.dro? || @solr_doc.collection? %>
+        <% component.with_tab(id: 'purl-preview-tab', pane_id: 'purl-preview-pane', label: 'Description Preview') if @solr_doc.purl? %>
         <% component.with_tab(id: 'files-tab', pane_id: 'files-pane', label: 'Files') if @solr_doc.dro? %>
         <% component.with_tab(id: 'workflows-tab', pane_id: 'workflows-pane', label: 'Workflows') %>
         <% component.with_tab(id: 'versions-tab', pane_id: 'versions-pane', label: 'Versions') %>
@@ -94,7 +97,7 @@
           <% end %>
         <% end %>
 
-        <% if @solr_doc.dro? || @solr_doc.collection? %>
+        <% if @solr_doc.purl? %>
           <%= component.with_pane(id: 'purl-preview-pane', tab_id: 'purl-preview-tab') do %>
             <%= turbo_frame_tag(@solr_doc.druid, 'purl_preview', src: purl_preview_object_path(druid: @druid_token), refresh: 'morph', target: '_top') do %>
               <%= render SdrViewComponents::Elements::SpinnerComponent.new %>

--- a/app/views/objects/show_purl_preview.html.erb
+++ b/app/views/objects/show_purl_preview.html.erb
@@ -1,6 +1,7 @@
 <%= turbo_frame_tag(@cocina_hash[:externalIdentifier], 'purl_preview') do %>
+  <p><%= link_to_purl(@cocina_hash[:externalIdentifier]) %></p>
   <% if @preview %>
-  <%= @preview %>
+    <%= @preview %>
   <% else %>
     <%= render SdrViewComponents::Elements::AlertComponent.new(text: 'PURL preview is not available.', variant: :note) %>
   <% end %>

--- a/spec/requests/show/show_purl_preview_spec.rb
+++ b/spec/requests/show/show_purl_preview_spec.rb
@@ -29,6 +29,8 @@ RSpec.describe 'Show purl preview' do
 
       expect(response).to have_http_status(:ok)
       expect(response.body).to include('PURL preview is not available.')
+      expect(response.body).to include('View PURL page')
+      expect(response.body).to include("https://purl.stanford.edu/#{DruidSupport.bare_druid_from(druid)}")
       expect(PurlPreviewService).to have_received(:call).with(cocina_hash:)
       expect(Honeybadger).to have_received(:notify).with(error, context: { cocina_hash: })
     end

--- a/spec/services/solr_doc_presenter_spec.rb
+++ b/spec/services/solr_doc_presenter_spec.rb
@@ -48,9 +48,53 @@ RSpec.describe SolrDocPresenter do
     end
   end
 
+  describe '#agreement?' do
+    context 'when the object type is agreement' do
+      let(:object_type) { 'agreement' }
+
+      it 'returns true' do
+        expect(presenter.agreement?).to be true
+      end
+    end
+
+    context 'when the object type is not agreement' do
+      let(:object_type) { 'item' }
+
+      it 'returns false' do
+        expect(presenter.agreement?).to be false
+      end
+    end
+  end
+
+  describe '#virtual_object?' do
+    context 'when the object type is virtual object' do
+      let(:object_type) { 'virtual object' }
+
+      it 'returns true' do
+        expect(presenter.virtual_object?).to be true
+      end
+    end
+
+    context 'when the object type is not agreement' do
+      let(:object_type) { 'item' }
+
+      it 'returns false' do
+        expect(presenter.agreement?).to be false
+      end
+    end
+  end
+
   describe '#dro?' do
     context 'when the object type is collection' do
       let(:object_type) { 'collection' }
+
+      it 'returns false' do
+        expect(presenter.dro?).to be false
+      end
+    end
+
+    context 'when the object type is agreement' do
+      let(:object_type) { 'agreement' }
 
       it 'returns false' do
         expect(presenter.dro?).to be false
@@ -70,6 +114,48 @@ RSpec.describe SolrDocPresenter do
 
       it 'returns true' do
         expect(presenter.dro?).to be true
+      end
+    end
+  end
+
+  describe '#purl?' do
+    context 'when the object type is item' do
+      let(:object_type) { 'item' }
+
+      it 'returns true' do
+        expect(presenter.purl?).to be true
+      end
+    end
+
+    context 'when the object type is collection' do
+      let(:object_type) { 'collection' }
+
+      it 'returns true' do
+        expect(presenter.purl?).to be true
+      end
+    end
+
+    context 'when the object type is virtual object' do
+      let(:object_type) { 'virtual object' }
+
+      it 'returns true' do
+        expect(presenter.purl?).to be true
+      end
+    end
+
+    context 'when the object type is admin policy' do
+      let(:object_type) { 'adminPolicy' }
+
+      it 'returns false' do
+        expect(presenter.purl?).to be false
+      end
+    end
+
+    context 'when the object type is agreement' do
+      let(:object_type) { 'agreement' }
+
+      it 'returns false' do
+        expect(presenter.purl?).to be false
       end
     end
   end

--- a/spec/services/solr_doc_presenter_spec.rb
+++ b/spec/services/solr_doc_presenter_spec.rb
@@ -118,12 +118,12 @@ RSpec.describe SolrDocPresenter do
     end
   end
 
-  describe '#purl?' do
+  describe '#dro_or_collection?' do
     context 'when the object type is item' do
       let(:object_type) { 'item' }
 
       it 'returns true' do
-        expect(presenter.purl?).to be true
+        expect(presenter.dro_or_collection?).to be true
       end
     end
 
@@ -131,7 +131,7 @@ RSpec.describe SolrDocPresenter do
       let(:object_type) { 'collection' }
 
       it 'returns true' do
-        expect(presenter.purl?).to be true
+        expect(presenter.dro_or_collection?).to be true
       end
     end
 
@@ -139,7 +139,7 @@ RSpec.describe SolrDocPresenter do
       let(:object_type) { 'virtual object' }
 
       it 'returns true' do
-        expect(presenter.purl?).to be true
+        expect(presenter.dro_or_collection?).to be true
       end
     end
 
@@ -147,7 +147,7 @@ RSpec.describe SolrDocPresenter do
       let(:object_type) { 'adminPolicy' }
 
       it 'returns false' do
-        expect(presenter.purl?).to be false
+        expect(presenter.dro_or_collection?).to be false
       end
     end
 
@@ -155,7 +155,7 @@ RSpec.describe SolrDocPresenter do
       let(:object_type) { 'agreement' }
 
       it 'returns false' do
-        expect(presenter.purl?).to be false
+        expect(presenter.dro_or_collection?).to be false
       end
     end
   end

--- a/spec/system/show_admin_policy_spec.rb
+++ b/spec/system/show_admin_policy_spec.rb
@@ -64,6 +64,9 @@ RSpec.describe 'Show admin policy' do
     expect(page).to have_css('h2', text: 'Depositing...')
     expect(page).to have_text('Actions unavailable until deposit is complete.')
 
+    # No PURL link for admin policies
+    expect(page).to have_no_link('View PURL page')
+
     # Tabs
     expect(page).to have_css('.nav-link.active', text: 'Overview')
     expect(page).to have_css('.nav-link', text: 'Workflows')
@@ -71,6 +74,7 @@ RSpec.describe 'Show admin policy' do
     expect(page).to have_css('.nav-link', text: 'Events')
     expect(page).to have_css('.nav-link', text: 'Cocina JSON')
     expect(page).to have_css('.nav-link', text: 'SOLR doc')
+    expect(page).to have_no_css('.nav-link', text: 'Description Preview')
 
     # Overview table
     expect(page).to have_css('table[id="overview-table"] caption', text: 'Overview')

--- a/spec/system/show_collection_spec.rb
+++ b/spec/system/show_collection_spec.rb
@@ -82,6 +82,9 @@ RSpec.describe 'Show collection' do
     expect(page).to have_css('.nav-link', text: 'SOLR doc')
     expect(page).to have_css('.nav-link', text: 'Description Preview')
 
+    # PURL link in side nav
+    expect(page).to have_link('View PURL page', href: "https://purl.stanford.edu/#{DruidSupport.bare_druid_from(druid)}")
+
     # Overview table
     expect(page).to have_css('table[id="overview-table"] caption', text: 'Overview')
     expect(page).to have_table_value('overview-table', 'Object type', 'Collection')
@@ -120,6 +123,8 @@ RSpec.describe 'Show collection' do
     # PURL preview tab
     click_button 'Description Preview'
     expect(page).to have_css('p', text: 'preview')
+    expect(page).to have_link('View PURL page',
+                              href: "https://purl.stanford.edu/#{DruidSupport.bare_druid_from(druid)}", count: 2)
 
     allow(Sdr::Repository).to receive(:find_solr).and_return(build_solr_doc(title: updated_title))
     allow(Sdr::Repository).to receive(:find)

--- a/spec/system/show_dro_spec.rb
+++ b/spec/system/show_dro_spec.rb
@@ -216,6 +216,9 @@ RSpec.describe 'Show DRO' do
     # Thumbnail
     expect(page).to have_css('img.thumbnail[src="http://stacks.stanford.edu/image/iiif/bb123cd4567%2Frr624wq8610_00_0001/full/!160,160/0/default.jpg"]') # rubocop:disable Layout/LineLength
 
+    # PURL link in side nav
+    expect(page).to have_link('View PURL page', href: "https://purl.stanford.edu/#{DruidSupport.bare_druid_from(druid)}")
+
     # Identification table
     expect(page).to have_table_caption('identification-table', 'Identification')
     expect(page).to have_table_value('identification-table', 'Druid', druid)
@@ -323,6 +326,8 @@ RSpec.describe 'Show DRO' do
     # PURL preview tab
     click_button 'Description Preview'
     expect(page).to have_css('p', text: 'preview')
+    expect(page).to have_link('View PURL page',
+                              href: "https://purl.stanford.edu/#{DruidSupport.bare_druid_from(druid)}", count: 2)
 
     # Update the object and look for changes.
     allow(Sdr::Repository).to receive(:find_solr).and_return(build_solr_doc(title: updated_title))


### PR DESCRIPTION
Fixes #257 

<img width="1127" height="683" alt="Screenshot 2026-08-18 at 9 57 00 AM" src="https://github.com/user-attachments/assets/d4a2a734-f45d-404a-aff2-b1bbb4178efd" />

Note: this shows the PURL link for virtual objects, collections and items.  I also adjusted some logic to ensure agreements don't get counted as DROs... which I presume is correct?