### PR TITLE
Give devs access to Mission Control

### DIFF
--- a/app/policies/mission_control/jobs/queues_policy.rb
+++ b/app/policies/mission_control/jobs/queues_policy.rb
@@ -10,7 +10,11 @@ module MissionControl
       alias_rule :index?, :create?, :new?, to: :manage?
 
       def manage?
-        admin? || Rails.env.development?
+        admin? || developer? || Rails.env.development?
+      end
+
+      def developer?
+        user.groups.include?('sdr:developer')
       end
     end
   end

--- a/spec/factories/users.rb
+++ b/spec/factories/users.rb
@@ -9,5 +9,9 @@ FactoryBot.define do
     trait :admin do
       groups { ['sdr:argo-access', AuthenticationHelpers::ADMIN_GROUP] }
     end
+
+    trait :developer do
+      groups { ['sdr:developer'] }
+    end
   end
 end

--- a/spec/requests/mission_control_jobs_spec.rb
+++ b/spec/requests/mission_control_jobs_spec.rb
@@ -25,5 +25,16 @@ RSpec.describe 'MissionControl jobs' do
         expect(response.body).to include('Mission control - Queues')
       end
     end
+
+    context 'with developer user' do
+      let(:user) { create(:user, :developer) }
+
+      it 'renders the mission control interface' do
+        get mission_control_jobs_path
+
+        expect(response).to have_http_status(:ok)
+        expect(response.body).to include('Mission control - Queues')
+      end
+    end
   end
 end


### PR DESCRIPTION
Fixes #362. I tested on QA and was able to access `/jobs`, where I previously could not. 