### PR TITLE
Use solr test instances instead of development instance.

### DIFF
--- a/config/settings/test.yml
+++ b/config/settings/test.yml
@@ -1,5 +1,5 @@
 solr:
-  url: http://localhost:<%= 8983 + (ENV['TEST_ENV_NUMBER'] || 1).to_i %>/solr/argo
+  url: http://localhost:<%= 8983 + (ENV['TEST_ENV_NUMBER'].presence || 1).to_i %>/solr/argo
 
 bulk_actions:
   directory: "tmp/bulk_jobs_test"


### PR DESCRIPTION
The development solr instance was accidentally getting used / wiped instead of the test instance.