### PR TITLE
implement goto druid from dashboard

### DIFF
--- a/app/controllers/dashboard_controller.rb
+++ b/app/controllers/dashboard_controller.rb
@@ -2,7 +2,19 @@
 
 # Controller for the dashboard (root page)
 class DashboardController < ApplicationController
-  skip_verify_authorized only: %i[index]
+  skip_verify_authorized only: %i[index go_to_druid]
 
-  def index; end
+  def index
+    @go_to_druid_form = GoToDruidForm.new
+  end
+
+  def go_to_druid
+    @go_to_druid_form = GoToDruidForm.new(params.expect(go_to_druid: [:druid]))
+
+    if @go_to_druid_form.valid?
+      redirect_to object_path(@go_to_druid_form.druid)
+    else
+      render :index, status: :unprocessable_content
+    end
+  end
 end

--- a/app/forms/go_to_druid_form.rb
+++ b/app/forms/go_to_druid_form.rb
@@ -3,4 +3,20 @@
 # Form for "Go to druid" on dashboard
 class GoToDruidForm < ApplicationForm
   attribute :druid, :string
+
+  normalizes :druid, with: lambda { |druid|
+    druid = druid&.strip
+    druid.present? && !druid.start_with?('druid:') ? "druid:#{druid}" : druid
+  }
+
+  validates :druid, druid: true
+  validate :druid_exists, if: -> { errors[:druid].empty? }
+
+  private
+
+  def druid_exists
+    Sdr::Repository.find_solr(druid:)
+  rescue Sdr::Repository::NotFoundResponse
+    errors.add(:druid, 'does not exist')
+  end
 end

--- a/app/views/dashboard/index.html.erb
+++ b/app/views/dashboard/index.html.erb
@@ -17,7 +17,7 @@
     <% end %>
     <% layout.with_left_content do %>
       <%= render SdrViewComponents::Elements::HeadingComponent.new(level: :h2, classes: 'mb-0', text: 'Go to a druid') %>
-      <%= form_with model: GoToDruidForm.new, url: '#', class: 'mb-5' do |form| %>
+      <%= form_with model: @go_to_druid_form, url: go_to_druid_path, class: 'mb-5' do |form| %>
           <div class="d-flex">
             <%= render SdrViewComponents::Forms::TextFieldComponent.new(form:,
                                                                         field_name: :druid,

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -17,6 +17,7 @@ Rails.application.routes.draw do
 
   # Defines the root path route ("/")
   root 'dashboard#index'
+  post 'go_to_druid', to: 'dashboard#go_to_druid'
 
   # resource :home, only: [:show], controller: 'home'
 

--- a/spec/forms/go_to_druid_form_spec.rb
+++ b/spec/forms/go_to_druid_form_spec.rb
@@ -1,0 +1,48 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe GoToDruidForm do
+  subject(:form) { described_class.new(druid:) }
+
+  let(:druid) { 'druid:bc123df4567' }
+
+  before do
+    allow(Sdr::Repository).to receive(:find_solr).with(druid:).and_return({})
+  end
+
+  it 'is valid when the druid exists' do
+    expect(form).to be_valid
+  end
+
+  context 'when the druid is blank' do
+    let(:druid) { '' }
+
+    it 'is not valid' do
+      expect(form).not_to be_valid
+      expect(form.errors[:druid]).to include('is not a valid druid')
+      expect(Sdr::Repository).not_to have_received(:find_solr)
+    end
+  end
+
+  context 'when the druid is malformed' do
+    let(:druid) { 'not-a-druid' }
+
+    it 'is not valid' do
+      expect(form).not_to be_valid
+      expect(form.errors[:druid]).to include('is not a valid druid')
+      expect(Sdr::Repository).not_to have_received(:find_solr)
+    end
+  end
+
+  context 'when the druid does not exist' do
+    before do
+      allow(Sdr::Repository).to receive(:find_solr).with(druid:).and_raise(Sdr::Repository::NotFoundResponse)
+    end
+
+    it 'is not valid' do
+      expect(form).not_to be_valid
+      expect(form.errors[:druid]).to include('does not exist')
+    end
+  end
+end

--- a/spec/requests/dashboard_spec.rb
+++ b/spec/requests/dashboard_spec.rb
@@ -4,6 +4,7 @@ require 'rails_helper'
 
 RSpec.describe 'Dashboard' do
   let(:user) { create(:user) }
+  let(:druid) { 'druid:bc123df4567' }
 
   before do
     sign_in(user)
@@ -13,5 +14,48 @@ RSpec.describe 'Dashboard' do
     get root_path
 
     expect(response).to have_http_status(:ok)
+  end
+
+  describe 'POST /go_to_druid' do
+    before do
+      allow(Sdr::Repository).to receive(:find_solr).with(druid:).and_return({})
+    end
+
+    it 'redirects to the object when given a prefixed druid' do
+      post go_to_druid_path, params: { go_to_druid: { druid: } }
+
+      expect(response).to redirect_to(object_path(druid))
+      expect(Sdr::Repository).to have_received(:find_solr).with(druid:)
+    end
+
+    it 'redirects to the object when given an unprefixed druid' do
+      post go_to_druid_path, params: { go_to_druid: { druid: 'bc123df4567' } }
+
+      expect(response).to redirect_to(object_path(druid))
+      expect(Sdr::Repository).to have_received(:find_solr).with(druid:)
+    end
+
+    context 'when the druid does not exist' do
+      before do
+        allow(Sdr::Repository).to receive(:find_solr).with(druid:).and_raise(Sdr::Repository::NotFoundResponse)
+      end
+
+      it 'renders a validation error' do
+        post go_to_druid_path, params: { go_to_druid: { druid: } }
+
+        expect(response).to have_http_status(:unprocessable_content)
+        expect(response.body).to include('does not exist')
+      end
+    end
+
+    context 'when the druid is invalid' do
+      it 'renders a validation error without looking up the object' do
+        post go_to_druid_path, params: { go_to_druid: { druid: 'not-a-druid' } }
+
+        expect(response).to have_http_status(:unprocessable_content)
+        expect(response.body).to include('is not a valid druid')
+        expect(Sdr::Repository).not_to have_received(:find_solr)
+      end
+    end
   end
 end


### PR DESCRIPTION
Fixes #271 

On success, goes to the druid page.  "druid:" prefix is optional

On druid not found, or invalid/missing format, shows error message:

<img width="325" height="237" alt="Screenshot 2026-08-20 at 11 08 48 AM" src="https://github.com/user-attachments/assets/ff75ca02-9e09-4d9c-a652-42de39540bbc" />

<img width="401" height="338" alt="Screenshot 2026-08-20 at 11 08 40 AM" src="https://github.com/user-attachments/assets/fc3ce335-9496-4224-989e-4a69b10bf1ae" />

Note: Claude code assisted.  Full specs for dashboard controller too may be a bit overboard though.