### PR TITLE
Initial display of structural metadata on files tab

### DIFF
--- a/app/assets/stylesheets/show.scss
+++ b/app/assets/stylesheets/show.scss
@@ -38,6 +38,10 @@
       border-bottom: 0;
     }
   }
+
+  .file-set-card {
+    background-color: var(--stanford-fog-light);
+  }
 }
 
 @mixin object-type-colors($color, $color-rgb) {

--- a/app/components/show/file_set_component.html.erb
+++ b/app/components/show/file_set_component.html.erb
@@ -1,0 +1,59 @@
+<%= tag.div class: classes do %>
+  <div class="card-body">
+    <div class="card-title d-flex justify-content-between">
+      <div>
+        <span class="h3">Resource (<%= index %>):</span> <%= file_set_type %>
+      </div>
+      <% if label.present? %>
+        <div>
+          <span class="fw-bold">Label:</span> <%= label %>
+        </div>
+      <% end %>
+    </div>
+    <div class="card-body">
+      <%= render(SdrViewComponents::Tables::TableComponent.new(label: "Files for resource #{index}",
+                                                               show_label: false,
+                                                               classes: 'border')) do |component| %>
+        <% component.with_header(label: 'File name', style: 'width: 30%;') %>
+        <% component.with_header(label: 'View') %>
+        <% component.with_header(label: 'Download') %>
+        <% component.with_header(label: 'Location') %>
+        <% component.with_header(label: 'Publish') %>
+        <% component.with_header(label: 'Preserve') %>
+        <% component.with_header(label: 'Role') %>
+        <% component.with_header(label: 'Language') %>
+        <% content_file_set.content_files.each do |content_file| %>
+          <% component.with_row do |row_component| %>
+            <%= row_component.with_cell do %>
+              <%= content_file.filepath %>
+              <div class="mt-2">
+                Size: <%= helpers.number_to_human_size(content_file.size) %><% if content_file.mime_type %>; Type: <%= content_file.mime_type %> <% end %>
+              </div>
+            <% end %>
+            <%= row_component.with_cell do %>
+              <%= content_file.view.capitalize %>
+            <% end %>
+            <%= row_component.with_cell do %>
+              <%= content_file.download&.capitalize %>
+            <% end %>
+            <%= row_component.with_cell do %>
+              <%= t("access.locations.#{content_file.location}") if content_file.location %>
+            <% end %>
+            <%= row_component.with_cell do %>
+              <%= '✔' if content_file.publish %>
+            <% end %>
+            <%= row_component.with_cell do %>
+              <%= '✔' if content_file.preserve %>
+            <% end %>
+            <%= row_component.with_cell do %>
+              <%= content_file.use&.capitalize || 'No role' %>
+            <% end %>
+            <%= row_component.with_cell do %>
+              <%= content_file.language_tag %>
+            <% end %>
+          <% end %>
+        <% end %>
+      <% end %>
+    </div>
+  </div>
+<% end %>

--- a/app/components/show/file_set_component.rb
+++ b/app/components/show/file_set_component.rb
@@ -1,0 +1,23 @@
+# frozen_string_literal: true
+
+module Show
+  # Component for displaying a file set (resource)
+  class FileSetComponent < ApplicationComponent
+    with_collection_parameter :content_file_set
+
+    def initialize(content_file_set:, content_file_set_counter:, classes: [])
+      @content_file_set = content_file_set
+      @index = content_file_set_counter + 1
+      @classes = classes
+      super()
+    end
+
+    attr_reader :content_file_set, :index
+
+    delegate :file_set_type, :label, to: :content_file_set
+
+    def classes
+      merge_classes('card file-set-card', @classes)
+    end
+  end
+end

--- a/app/views/objects/show_files.html.erb
+++ b/app/views/objects/show_files.html.erb
@@ -1,4 +1,8 @@
 <%= turbo_frame_tag(@content.druid, 'files') do %>
+  <%= render SdrViewComponents::Elements::HeadingComponent.new(level: :h2, text: 'Structural metadata', classes: 'mb-3') %>
+  <%= render Show::FileSetComponent.with_collection(@content.content_file_sets, classes: 'mb-2') %>
+
+  <%= render SdrViewComponents::Elements::HeadingComponent.new(level: :h2, text: 'Files', classes: 'mt-5 mb-3') %>
   <ul>
     <% @content.content_file_binaries.each do |content_file_binary| %>
       <li><%= content_file_binary.filepath %></li>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -128,3 +128,11 @@ en:
             label: "Enter prefix to autogenerate source ID"
         title:
           label: "Title"
+  access:
+    locations:
+      spec: "Special collections"
+      music: "Music"
+      ars: "ARS"
+      art: "Art"
+      hoover: "Hoover Institute"
+      m&m: "Media and Microtext"

--- a/spec/components/show/file_set_component_spec.rb
+++ b/spec/components/show/file_set_component_spec.rb
@@ -1,0 +1,87 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe Show::FileSetComponent, type: :component do
+  let(:component) { described_class.new(content_file_set:, content_file_set_counter: 1) }
+
+  let(:content_file_set) do
+    instance_double(ContentFileSet, file_set_type: 'file', label: 'Resource 2', content_files: [content_file])
+  end
+
+  let(:content_file) do
+    instance_double(ContentFile,
+                    filepath: 'image1.tif',
+                    size: 1024,
+                    mime_type: 'image/tiff',
+                    view: 'world',
+                    download: 'stanford',
+                    location: 'spec',
+                    publish: true,
+                    preserve: true,
+                    use: 'transcription',
+                    language_tag: 'en')
+  end
+
+  it 'renders the resource heading and label' do
+    render_inline(component)
+
+    expect(page).to have_css('.card-title', text: 'Resource (2): file')
+    expect(page).to have_css('.card-title', text: 'Label: Resource 2')
+  end
+
+  it 'renders a row for each content file' do
+    render_inline(component)
+
+    expect(page).to have_css("table[aria-label='Files for resource 2']")
+    expect(page).to have_css('th', text: 'File name')
+    expect(page).to have_css('td', text: 'image1.tif')
+    expect(page).to have_css('td', text: 'Size: 1 KB; Type: image/tiff')
+    expect(page).to have_css('td', text: 'World')
+    expect(page).to have_css('td', text: 'Stanford')
+    expect(page).to have_css('td', text: 'Special collections')
+    expect(page).to have_css('td', text: 'Transcription')
+    expect(page).to have_css('td', text: 'en')
+  end
+
+  it 'shows checkmarks for publish and preserve' do
+    render_inline(component)
+
+    expect(page).to have_css('td', text: '✔', count: 2)
+  end
+
+  context 'when the content file has no location' do
+    let(:content_file) do
+      instance_double(ContentFile,
+                      filepath: 'image1.tif',
+                      size: 1024,
+                      mime_type: 'image/tiff',
+                      view: 'world',
+                      download: 'stanford',
+                      location: nil,
+                      publish: false,
+                      preserve: false,
+                      use: nil,
+                      language_tag: nil)
+    end
+
+    it 'renders an empty location cell and no checkmarks' do
+      render_inline(component)
+
+      expect(page).to have_css('td', text: 'No role')
+      expect(page).to have_css('td', text: '✔', count: 0)
+    end
+  end
+
+  context 'when the label is blank' do
+    let(:content_file_set) do
+      instance_double(ContentFileSet, file_set_type: 'file', label: '', content_files: [content_file])
+    end
+
+    it 'does not render a label' do
+      render_inline(component)
+
+      expect(page).to have_no_css('.card-title', text: 'Label:')
+    end
+  end
+end

--- a/spec/system/show_dro_spec.rb
+++ b/spec/system/show_dro_spec.rb
@@ -321,6 +321,16 @@ RSpec.describe 'Show DRO' do
 
     # Files tab
     click_button 'Files'
+
+    # Structural metadata section
+    expect(page).to have_css('h2', text: 'Structural metadata')
+    within('.file-set-card', text: 'Resource (1): file') do
+      expect(page).to have_css('.card-title', text: 'Label: Object 1')
+      expect(page).to have_css('td', text: 'rr624wq8610_00_0001.jp2')
+    end
+
+    # Files section
+    expect(page).to have_css('h2', text: 'Files')
     expect(page).to have_css('li', text: 'rr624wq8610_00_0001.jp2')
 
     # PURL preview tab

--- a/spec/system/show_item_spec.rb
+++ b/spec/system/show_item_spec.rb
@@ -2,7 +2,7 @@
 
 require 'rails_helper'
 
-RSpec.describe 'Show DRO' do
+RSpec.describe 'Show item' do
   let(:druid) { 'druid:bb123cd4567' }
   let(:apo_druid) { 'druid:cc123cd4578' }
   let(:collection_druid) { 'druid:dd123cd4589' }


### PR DESCRIPTION
closes #379

<img width="3226" height="4602" alt="image" src="https://github.com/user-attachments/assets/5189fbd8-769e-48ff-8d3c-813224caee61" />
