### PR TITLE
Object "Released to" box on show page

### DIFF
--- a/app/components/show/released_to_component.html.erb
+++ b/app/components/show/released_to_component.html.erb
@@ -1,0 +1,9 @@
+<%= render Show::BoxComponent.new(heading:) do %>
+  <% if release_tag_links.any? %>
+    <ul>
+      <% release_tag_links.each do |release_tag_link| %>
+        <li><%= helpers.link_to_new_tab(release_tag_link[:label], release_tag_link[:url]) %></li>
+      <% end %>
+    </ul>
+  <% end %>
+<% end %>

--- a/app/components/show/released_to_component.rb
+++ b/app/components/show/released_to_component.rb
@@ -1,0 +1,15 @@
+# frozen_string_literal: true
+
+module Show
+  # Component for rendering the released to box on the show page.
+  class ReleasedToComponent < ApplicationComponent
+    def initialize(object_released_presenter:)
+      @object_released_presenter = object_released_presenter
+      super()
+    end
+
+    attr_reader :object_released_presenter
+
+    delegate :heading, :release_tag_links, to: :object_released_presenter
+  end
+end

--- a/app/controllers/objects_controller.rb
+++ b/app/controllers/objects_controller.rb
@@ -22,7 +22,7 @@ class ObjectsController < ApplicationController
   # keeps the frame actions themselves unaware of the lock: they just read whatever is in the cache,
   # trusting that this action (which always runs moments before them, as the parent page load) has
   # already made it fresh.
-  def show
+  def show # rubocop:disable Metrics/AbcSize
     druid = params[:druid]
     lock = Sdr::Repository.lock(druid:)
 
@@ -35,7 +35,10 @@ class ObjectsController < ApplicationController
     @druid_token = generate_token(druid)
     version_service = Sdr::VersionService.new(druid:)
     content = Content.find_by(druid:, lock:, immutable: false)
-    @object_status_presenter = ObjectStatusPresenter.new(document: @solr_doc, version_service:, content:)
+    @object_status_presenter = ObjectStatusPresenter.new(document: @solr_doc, version_service:,
+                                                         content:)
+    release_tags = @solr_doc.dro_or_collection? ? Sdr::Repository.release_tags(druid:) : []
+    @object_released_presenter = ObjectReleasedPresenter.new(document: @solr_doc, version_service:, release_tags:)
   end
 
   def show_header

--- a/app/helpers/link_helper.rb
+++ b/app/helpers/link_helper.rb
@@ -13,4 +13,12 @@ module LinkHelper
   def link_to_purl(druid, *, data: {}, **, &)
     link_to_new_tab('View PURL page', Cocina::Models::Mapping::Purl.for(druid:), *, data:, **, &)
   end
+
+  def searchworks_url(druid, catalog_record_id = nil)
+    "#{Settings.searchworks.url}/view/#{catalog_record_id.presence || druid}"
+  end
+
+  def earthworks_url(druid)
+    "#{Settings.earthworks.url}/catalog/stanford-#{DruidSupport.bare_druid_from(druid)}"
+  end
 end

--- a/app/presenters/object_released_presenter.rb
+++ b/app/presenters/object_released_presenter.rb
@@ -1,0 +1,49 @@
+# frozen_string_literal: true
+
+# Presenter for the release status and release target links of an object.
+class ObjectReleasedPresenter
+  include LinkHelper
+
+  def initialize(document:, version_service:, release_tags:)
+    @document = document
+    @version_service = version_service
+    @release_tags = release_tags
+  end
+
+  def heading
+    return I18n.t('show.released_to.unreleased.heading') if unreleased?
+
+    I18n.t('show.released_to.released.heading')
+  end
+
+  def release_tag_links
+    release_tags.map { |release_tag| { label: release_tag.to, url: release_tag_url(release_tag) } }
+  end
+
+  private
+
+  attr_reader :document, :version_service, :release_tags
+
+  def unreleased?
+    release_tags.empty? || undeposited?
+  end
+
+  def undeposited?
+    version_service.version == 1 && (version_service.open? || version_service.accessioning?)
+  end
+
+  def release_tag_url(release_tag)
+    case release_tag.to
+    when 'PURL sitemap'
+      Cocina::Models::Mapping::Purl.for(druid: document.druid)
+    when 'Searchworks'
+      searchworks_url(document.druid, catalog_record_id)
+    when 'Earthworks'
+      earthworks_url(document.druid)
+    end
+  end
+
+  def catalog_record_id
+    Array(document.catalog_record_id).first
+  end
+end

--- a/app/services/sdr/repository.rb
+++ b/app/services/sdr/repository.rb
@@ -118,5 +118,12 @@ module Sdr
     rescue Dor::Services::Client::Error => e
       raise Error, "Creating release tag failed: #{e.message}"
     end
+
+    # @param [String] druid the druid of the object
+    def self.release_tags(druid:)
+      Dor::Services::Client.object(druid).release_tags.list(public: true)
+    rescue Dor::Services::Client::NotFoundResponse
+      raise NotFoundResponse, "Object not found: #{druid}"
+    end
   end
 end

--- a/app/views/objects/show.html.erb
+++ b/app/views/objects/show.html.erb
@@ -58,15 +58,11 @@
         <div class="show-box flex-fill">
           <%= render Show::StatusComponent.new(object_status_presenter: @object_status_presenter) %>
         </div>
-        <div class="show-box flex-fill">
-          <%= render Show::BoxComponent.new(heading: 'Released to') do %>
-            <ul>
-              <li>SearchWorks</li>
-              <li>EarthWorks</li>
-              <li>PURL Sitemap</li>
-            </ul>
-          <% end %>
-        </div>
+        <% if @solr_doc.dro_or_collection? %>
+          <div class="show-box flex-fill">
+            <%= render Show::ReleasedToComponent.new(object_released_presenter: @object_released_presenter) %>
+          </div>
+        <% end %>
         <div class="show-box flex-fill">
           <%= render Show::BoxComponent.new(heading: 'Tags') do %>
             <ul>

--- a/bin/dev-server
+++ b/bin/dev-server
@@ -58,11 +58,18 @@ trap 'kill "$TUNNEL_PID" 2>/dev/null' EXIT
 sleep 2
 
 
-# stacks and purl-fetcher have no qa environment of their own; qa falls back to stage.
+# stacks, earthworks, and purl-fetcher have no qa environment of their own; qa falls back to stage.
 if [ "$SERVER_ENV" = "qa" ]; then
   PURL_ENV="stage"
 else
   PURL_ENV="$SERVER_ENV"
+fi
+
+# searchworks has a shared preview instance for qa and stage; prod uses no env.
+if [ "$SERVER_ENV" = "qa" ] || [ "$SERVER_ENV" = "stage" ]; then
+  SEARCHWORKS_ENV="-preview-stage"
+else
+  SEARCHWORKS_ENV=""
 fi
 
 export SETTINGS__SOLR__URL="${SETTINGS__SOLR__URL:-http://localhost:8990/solr/argo_${SERVER_ENV}}"
@@ -70,5 +77,8 @@ export SETTINGS__DOR_SERVICES__URL="${SETTINGS__DOR_SERVICES__URL:-https://dor-s
 export SETTINGS__PRESERVATION_CATALOG__URL="${SETTINGS__PRESERVATION_CATALOG__URL:-https://preservation-catalog-${SERVER_ENV}.stanford.edu}"
 export SETTINGS__STACKS__URL="${SETTINGS__STACKS__URL:-https://stacks-${PURL_ENV}.stanford.edu/image}"
 export SETTINGS__PURL_FETCHER__URL="${SETTINGS__PURL_FETCHER__URL:-https://purl-fetcher-${PURL_ENV}.stanford.edu}"
+export SETTINGS__PURL__URL="${SETTINGS__PURL__URL:-https://sul-purl-${PURL_ENV}.stanford.edu}"
+export SETTINGS__SEARCHWORKS__URL="${SETTINGS__SEARCHWORKS__URL:-https://searchworks${SEARCHWORKS_ENV}.stanford.edu}"
+export SETTINGS__EARTHWORKS__URL="${SETTINGS__EARTHWORKS__URL:-https://earthworks-${PURL_ENV}.stanford.edu}"
 
 bin/setup

--- a/config/deploy.qa.yml
+++ b/config/deploy.qa.yml
@@ -21,6 +21,8 @@ env:
     SETTINGS__PURL_FETCHER__URL: https://purl-fetcher-stage.stanford.edu
     SETTINGS__PURL__URL: https://sul-purl-stage.stanford.edu
     SETTINGS__ARGO__URL: https://argo-qa.stanford.edu
+    SETTINGS__SEARCHWORKS__URL: https://searchworks-preview-stage.stanford.edu
+    SETTINGS__EARTHWORKS__URL: https://earthworks-stage.stanford.edu
     SETTINGS__FEATURE_FLAGS__BULK_ACTIONS: true
     
     DATABASE_HOSTNAME: argo-b3-db-qa-a

--- a/config/deploy.stage.yml
+++ b/config/deploy.stage.yml
@@ -21,6 +21,8 @@ env:
     SETTINGS__PURL_FETCHER__URL: https://purl-fetcher-stage.stanford.edu
     SETTINGS__PURL__URL: https://sul-purl-stage.stanford.edu
     SETTINGS__ARGO__URL: https://argo-stage.stanford.edu
+    SETTINGS__SEARCHWORKS__URL: https://searchworks-preview-stage.stanford.edu
+    SETTINGS__EARTHWORKS__URL: https://earthworks-stage.stanford.edu
     SETTINGS__FEATURE_FLAGS__BULK_ACTIONS: true
 
     DATABASE_HOSTNAME: argo-b3-db-stage-a

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -74,6 +74,11 @@ en:
         edit_item_details: "Edit item details"
         manage_files: "Manage files"
         manage_description: "Manage description"
+    released_to:
+      released:
+        heading: "Released to"
+      unreleased:
+        heading: "Not released"
   edit:
     contents:
       edit:

--- a/config/settings.yml
+++ b/config/settings.yml
@@ -33,6 +33,12 @@ purl:
 purl_fetcher:
   url: "https://purl-fetcher.stanford.edu"
 
+searchworks:
+  url: "https://searchworks.stanford.edu"
+
+earthworks:
+  url: "https://earthworks.stanford.edu"
+
 component_library:
   url: "https://cdn.jsdelivr.net/gh/sul-dlss/component-library@v2026-08-06"
 

--- a/spec/components/show/released_to_component_spec.rb
+++ b/spec/components/show/released_to_component_spec.rb
@@ -1,0 +1,39 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe Show::ReleasedToComponent, type: :component do
+  subject(:component) { described_class.new(object_released_presenter:) }
+
+  let(:heading) { 'Released to' }
+  let(:release_tag_links) do
+    [
+      { label: 'Searchworks', url: 'https://searchworks.stanford.edu/view/druid:bc123df4567' },
+      { label: 'PURL sitemap', url: 'https://purl.stanford.edu/bc123df4567' }
+    ]
+  end
+  let(:object_released_presenter) do
+    instance_double(ObjectReleasedPresenter, heading:, release_tag_links:)
+  end
+
+  context 'when there are release target links' do
+    it 'renders a link for each release target' do
+      render_inline(component)
+
+      expect(page).to have_link('Searchworks', href: 'https://searchworks.stanford.edu/view/druid:bc123df4567')
+      expect(page).to have_link('PURL sitemap', href: 'https://purl.stanford.edu/bc123df4567')
+    end
+  end
+
+  context 'when there are no release target links' do
+    let(:heading) { 'Not released' }
+    let(:release_tag_links) { [] }
+
+    it 'renders the heading and no list' do
+      render_inline(component)
+
+      expect(page).to have_css('h2', text: 'Not released')
+      expect(page).to have_no_css('ul')
+    end
+  end
+end

--- a/spec/helpers/link_helper_spec.rb
+++ b/spec/helpers/link_helper_spec.rb
@@ -1,0 +1,27 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe LinkHelper do
+  describe '#searchworks_url' do
+    let(:druid) { 'druid:bc123df4567' }
+
+    context 'when a catalog record id is present' do
+      it 'builds a url using the catalog record id' do
+        expect(helper.searchworks_url(druid, 'a1234567')).to eq('https://searchworks.stanford.edu/view/a1234567')
+      end
+    end
+
+    context 'when no catalog record id is present' do
+      it 'builds a url using the druid' do
+        expect(helper.searchworks_url(druid)).to eq("https://searchworks.stanford.edu/view/#{druid}")
+      end
+    end
+  end
+
+  describe '#earthworks_url' do
+    it 'builds a url using the bare druid' do
+      expect(helper.earthworks_url('druid:bb014tx0752')).to eq('https://earthworks.stanford.edu/catalog/stanford-bb014tx0752')
+    end
+  end
+end

--- a/spec/presenters/object_released_presenter_spec.rb
+++ b/spec/presenters/object_released_presenter_spec.rb
@@ -1,0 +1,71 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe ObjectReleasedPresenter do
+  subject(:presenter) { described_class.new(document:, version_service:, release_tags:) }
+
+  let(:druid) { 'druid:bc123df4567' }
+  let(:document) do
+    SolrDocPresenter.new(solr_doc: { Search::Fields::ID => druid,
+                                     Search::Fields::CATALOG_RECORD_ID => catalog_record_id })
+  end
+  let(:catalog_record_id) { [] }
+  let(:version_service) { instance_double(Sdr::VersionService, version: 2, open?: false, accessioning?: false) }
+
+  describe '#heading' do
+    context 'when there are no release tags' do
+      let(:release_tags) { [] }
+
+      it 'returns the unreleased heading' do
+        expect(presenter.heading).to eq(I18n.t('show.released_to.unreleased.heading'))
+      end
+    end
+
+    context 'when there are release tags' do
+      let(:release_tags) { [instance_double(Dor::Services::Client::ReleaseTag, to: 'Searchworks')] }
+
+      it 'returns the released heading' do
+        expect(presenter.heading).to eq(I18n.t('show.released_to.released.heading'))
+      end
+
+      context 'when the object is still undeposited' do
+        let(:version_service) { instance_double(Sdr::VersionService, version: 1, open?: true, accessioning?: false) }
+
+        it 'returns the unreleased heading' do
+          expect(presenter.heading).to eq(I18n.t('show.released_to.unreleased.heading'))
+        end
+      end
+    end
+  end
+
+  describe '#release_tag_links' do
+    let(:release_tags) do
+      [
+        instance_double(Dor::Services::Client::ReleaseTag, to: 'Searchworks'),
+        instance_double(Dor::Services::Client::ReleaseTag, to: 'Earthworks'),
+        instance_double(Dor::Services::Client::ReleaseTag, to: 'PURL sitemap')
+      ]
+    end
+
+    it 'returns a label and url for each release target' do
+      expect(presenter.release_tag_links).to eq(
+        [
+          { label: 'Searchworks', url: "https://searchworks.stanford.edu/view/#{druid}" },
+          { label: 'Earthworks', url: 'https://earthworks.stanford.edu/catalog/stanford-bc123df4567' },
+          { label: 'PURL sitemap', url: 'https://purl.stanford.edu/bc123df4567' }
+        ]
+      )
+    end
+
+    context 'when the object has a folio catalog record id' do
+      let(:catalog_record_id) { ['a1234567'] }
+
+      it 'links to Searchworks using the catalog record id instead of the druid' do
+        searchworks_link = presenter.release_tag_links.find { |link| link[:label] == 'Searchworks' }
+
+        expect(searchworks_link[:url]).to eq('https://searchworks.stanford.edu/view/a1234567')
+      end
+    end
+  end
+end

--- a/spec/services/sdr/repository_spec.rb
+++ b/spec/services/sdr/repository_spec.rb
@@ -303,4 +303,32 @@ RSpec.describe Sdr::Repository do
       end
     end
   end
+
+  describe '#release_tags' do
+    context 'when the object is found' do
+      let(:release_tags) { [instance_double(Dor::Services::Client::ReleaseTag)] }
+      let(:release_tags_client) { instance_double(Dor::Services::Client::ReleaseTags, list: release_tags) }
+      let(:object_client) { instance_double(Dor::Services::Client::Object, release_tags: release_tags_client) }
+
+      before do
+        allow(Dor::Services::Client).to receive(:object).and_return(object_client)
+      end
+
+      it 'returns the release tags' do
+        expect(described_class.release_tags(druid:)).to eq(release_tags)
+        expect(Dor::Services::Client).to have_received(:object).with(druid)
+        expect(release_tags_client).to have_received(:list).with(public: true)
+      end
+    end
+
+    context 'when the object is not found' do
+      before do
+        allow(Dor::Services::Client).to receive(:object).and_raise(Dor::Services::Client::NotFoundResponse)
+      end
+
+      it 'raises' do
+        expect { described_class.release_tags(druid:) }.to raise_error(Sdr::Repository::NotFoundResponse)
+      end
+    end
+  end
 end

--- a/spec/system/create_item_spec.rb
+++ b/spec/system/create_item_spec.rb
@@ -23,7 +23,8 @@ RSpec.describe 'Create an item' do
 
     let(:object_client) do
       instance_double(Dor::Services::Client::Object, version: version_client, milestones: milestones_client,
-                                                     user_version: user_version_client)
+                                                     user_version: user_version_client,
+                                                     release_tags: release_tags_client)
     end
     let(:version_client) { instance_double(Dor::Services::Client::ObjectVersion, inventory: [], status: version_status) }
     let(:version_status) do
@@ -31,6 +32,7 @@ RSpec.describe 'Create an item' do
     end
     let(:user_version_client) { instance_double(Dor::Services::Client::UserVersion, inventory: []) }
     let(:milestones_client) { instance_double(Dor::Services::Client::Milestones, list: []) }
+    let(:release_tags_client) { instance_double(Dor::Services::Client::ReleaseTags, list: []) }
 
     before do
       allow(Sdr::Repository).to receive_messages(accession: nil, create_release_tag: nil,

--- a/spec/system/manage_files_spec.rb
+++ b/spec/system/manage_files_spec.rb
@@ -11,7 +11,8 @@ RSpec.describe 'Manage files' do
 
   let(:object_client) do
     instance_double(Dor::Services::Client::Object, version: version_client, milestones: milestones_client,
-                                                   user_version: user_version_client, lock: 'abc123')
+                                                   user_version: user_version_client, lock: 'abc123',
+                                                   release_tags: release_tags_client)
   end
   let(:version_client) { instance_double(Dor::Services::Client::ObjectVersion, inventory: [], status: version_status) }
   let(:version_status) do
@@ -19,6 +20,7 @@ RSpec.describe 'Manage files' do
   end
   let(:user_version_client) { instance_double(Dor::Services::Client::UserVersion, inventory: []) }
   let(:milestones_client) { instance_double(Dor::Services::Client::Milestones, list: []) }
+  let(:release_tags_client) { instance_double(Dor::Services::Client::ReleaseTags, list: []) }
 
   before do
     sign_in(user)

--- a/spec/system/show_admin_policy_spec.rb
+++ b/spec/system/show_admin_policy_spec.rb
@@ -67,6 +67,10 @@ RSpec.describe 'Show admin policy' do
     # No PURL link for admin policies
     expect(page).to have_no_link('View PURL page')
 
+    # No released to box for admin policies
+    expect(page).to have_no_css('h2', text: 'Released to')
+    expect(page).to have_no_css('h2', text: 'Not released')
+
     # Tabs
     expect(page).to have_css('.nav-link.active', text: 'Overview')
     expect(page).to have_css('.nav-link', text: 'Workflows')

--- a/spec/system/show_collection_spec.rb
+++ b/spec/system/show_collection_spec.rb
@@ -12,6 +12,7 @@ RSpec.describe 'Show collection' do
   # Versions are tested in show_dro_spec so returning [].
   let(:object_client) do
     instance_double(Dor::Services::Client::Object, version: version_client, milestones: milestones_client,
+                                                   release_tags: release_tags_client,
                                                    user_version: user_version_client, lock: 'lock1')
   end
   let(:version_client) { instance_double(Dor::Services::Client::ObjectVersion, inventory: [], status: version_status) }
@@ -20,6 +21,7 @@ RSpec.describe 'Show collection' do
   end
   let(:user_version_client) { instance_double(Dor::Services::Client::UserVersion, inventory: []) }
   let(:milestones_client) { instance_double(Dor::Services::Client::Milestones, list: []) }
+  let(:release_tags_client) { instance_double(Dor::Services::Client::ReleaseTags, list: []) }
 
   def build_solr_doc(title:)
     {
@@ -72,6 +74,9 @@ RSpec.describe 'Show collection' do
 
     # Status box
     expect(page).to have_css('h2', text: 'Draft, not deposited')
+
+    # Released to box
+    expect(page).to have_css('h2', text: 'Not released')
 
     # Tabs
     expect(page).to have_css('.nav-link.active', text: 'Overview')

--- a/spec/system/show_item_spec.rb
+++ b/spec/system/show_item_spec.rb
@@ -21,17 +21,19 @@ RSpec.describe 'Show item' do
 
   let(:object_client) do
     instance_double(Dor::Services::Client::Object, version: version_client, milestones: milestones_client,
+                                                   release_tags: release_tags_client,
                                                    user_version: user_version_client, lock: 'lock1')
   end
   let(:version_client) do
     instance_double(Dor::Services::Client::ObjectVersion, inventory: version_inventory, status: version_status)
   end
   let(:version_status) do
-    instance_double(Dor::Services::Client::ObjectVersion::VersionStatus, accessioning?: false, closed?: true)
+    instance_double(Dor::Services::Client::ObjectVersion::VersionStatus, accessioning?: false, closed?: true,
+                                                                         version: 2)
   end
   let(:user_version_client) { instance_double(Dor::Services::Client::UserVersion, inventory: user_version_inventory) }
   let(:milestones_client) { instance_double(Dor::Services::Client::Milestones, list: milestones) }
-
+  let(:release_tags_client) { instance_double(Dor::Services::Client::ReleaseTags, list: release_tags) }
   let(:version_inventory) do
     [
       Dor::Services::Client::ObjectVersion::Version.new(versionId: 1, message: 'Initial version', cocina: true),
@@ -59,6 +61,15 @@ RSpec.describe 'Show item' do
       { milestone: 'published', at: '2021-03-31 21:01:20 +0000', version: '2' },
       { milestone: 'deposited', at: '2021-03-31 21:01:51 +0000', version: '2' },
       { milestone: 'accessioned', at: '2021-03-31 21:02:03 +0000', version: '2' }
+    ]
+  end
+
+  let(:release_tags) do
+    [
+      Dor::Services::Client::ReleaseTag.new(to: 'Searchworks', what: 'self', release: true,
+                                            date: '2026-08-01T21:02:03Z'),
+      Dor::Services::Client::ReleaseTag.new(to: 'PURL sitemap', what: 'self', release: true,
+                                            date: '2026-08-01T21:02:03Z')
     ]
   end
 
@@ -185,6 +196,11 @@ RSpec.describe 'Show item' do
     # Status box
     expect(page).to have_css('h2', text: 'Deposited')
     expect(page).to have_css('h2 i.bi-check-circle-fill')
+
+    # Released to box
+    expect(page).to have_css('h2', text: 'Released to')
+    expect(page).to have_link('Searchworks', href: 'https://searchworks.stanford.edu/view/a6525053')
+    expect(page).to have_link('PURL sitemap', href: "https://purl.stanford.edu/#{DruidSupport.bare_druid_from(druid)}")
 
     expect(page).to have_link('← Back to search', href: /search\?page=5&query=test/)
 


### PR DESCRIPTION
Closes #252.

Item with release tags:
<img width="1105" height="245" alt="Screenshot 2026-08-20 at 2 20 03 PM" src="https://github.com/user-attachments/assets/98d9fcd9-ed06-4f66-81e4-1a94011b65f1" />

Item that has not yet been released:
<img width="1070" height="231" alt="Screenshot 2026-08-20 at 2 58 09 PM" src="https://github.com/user-attachments/assets/e41c86fe-d9e9-4a37-99aa-a06f228a2b4f" />

Box does not display on APOs or Agreements. 
