### PR TITLE
use consistent default datetime formats

### DIFF
--- a/README.md
+++ b/README.md
@@ -342,9 +342,14 @@ Currently, excluding is only available for basic facets (i.e., not hierarchical,
 ## Conventions
 
 ### Dates / times
-All dates / times should be rendered in one of the formats defined in `en.yml` and in the "Pacific Time (US & Canada)" time zone.
+Application-rendered dates / times should use one of these formats, which are defined in `en.yml`:
 
-See the `format_datetime` helper.
+* `date_only`: `YYYY-MM-DD` (for example, `2026-07-29`)
+* `date_time`: `YYYY-MM-DD HH:MM:SS PT` (for example, `2026-07-29 14:56:58 PT`)
+
+Use the `format_datetime` helper, which defaults to `date_time` and renders values in the "Pacific Time (US & Canada)" time zone. Pass `format: :date_only` for a date without a time. The `PT` label is intentionally used year-round while the underlying time observes daylight saving time.
+
+CSV report values are an exception because Argo receives them as preformatted values from Solr. Machine-readable dates / times, such as Solr query values, repository API values, and HTTP headers, should continue to use the format required by their protocol.
 
 ### Notifications
 

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -15,7 +15,7 @@ module ApplicationHelper
     I18n.t("search.facet_values.#{value}", default: value.to_s.humanize)
   end
 
-  def format_datetime(datetime, format: :long)
+  def format_datetime(datetime, format: :date_time)
     return if datetime.blank?
 
     I18n.l(datetime.in_time_zone('Pacific Time (US & Canada)'), format:)

--- a/app/jobs/bulk_actions/base_job.rb
+++ b/app/jobs/bulk_actions/base_job.rb
@@ -4,6 +4,7 @@ module BulkActions
   # Superclass of all bulk action jobs
   class BaseJob < ApplicationJob
     include ActionPolicy::Behaviour
+    include ApplicationHelper
 
     attr_reader :bulk_action, :druids
 
@@ -46,7 +47,7 @@ module BulkActions
     end
 
     def log(message)
-      log_file.puts("#{Time.zone.now} #{message}")
+      log_file.puts("#{format_datetime(Time.zone.now)} #{message}")
     end
 
     # Subclasses must implement.

--- a/app/presenters/cocina_models/dro_presenter.rb
+++ b/app/presenters/cocina_models/dro_presenter.rb
@@ -19,7 +19,7 @@ module CocinaModels
 
       display_view = display_view(view: embargo_view, location: embargo_location)
       display_download = display_download(download: embargo_download, location: embargo_location)
-      "#{format_datetime(embargo_release_date)} - #{display_view}, #{display_download}"
+      "#{format_datetime(embargo_release_date, format: :date_only)} - #{display_view}, #{display_download}"
     end
 
     private

--- a/app/services/reports/fields.rb
+++ b/app/services/reports/fields.rb
@@ -25,7 +25,7 @@ module Reports
     ACCESSIONED_DATE = Config.new(
       field: Search::Fields::FORMATTED_EARLIEST_ACCESSIONED_DATE,
       label: 'Accessioned date',
-      help_text: 'For example: 2020-09-15 08:33:01 PM'
+      help_text: 'For example: 2020-09-15 20:33:01 PT'
     )
 
     APO_DRUID = Config.new(
@@ -103,7 +103,7 @@ module Reports
     EMBARGO_RELEASE_DATE = Config.new(
       field: Search::Fields::FORMATTED_EMBARGO_RELEASE_DATE,
       label: 'Embargo release date',
-      help_text: 'For example: 2025-12-04 04:00:00 PM'
+      help_text: 'For example: 2025-12-04'
     )
 
     FILE_COUNT = Config.new(
@@ -157,7 +157,7 @@ module Reports
     PUBLISHED_DATE = Config.new(
       field: Search::Fields::FORMATTED_PUBLISHED_EARLIEST_DATE,
       label: 'Published date',
-      help_text: 'For example: 2020-09-15 08:31:34 PM'
+      help_text: 'For example: 2020-09-15 20:31:34 PT'
     )
 
     PUBLISHER = Config.new(
@@ -181,7 +181,7 @@ module Reports
     REGISTERED_DATE = Config.new(
       field: Search::Fields::FORMATTED_REGISTERED_EARLIEST_DATE,
       label: 'Registered date',
-      help_text: 'For example: 2020-09-15 08:31:27 PM'
+      help_text: 'For example: 2020-09-15 20:31:27 PT'
     )
 
     RELEASED_TO = Config.new(

--- a/app/services/tracksheet_service.rb
+++ b/app/services/tracksheet_service.rb
@@ -6,6 +6,8 @@ require 'barby/outputter/prawn_outputter'
 
 # Generates a Prawn PDF tracking sheet for a single digital object.
 class TracksheetService
+  include ApplicationHelper
+
   # Directory containing the vendored TrueType fonts used to render the PDF.
   # A TTF font is required (instead of Prawn's built-in AFM fonts) so that
   # titles and other metadata containing UTF-8 characters can be rendered
@@ -131,7 +133,7 @@ class TracksheetService
     barcode = solr_doc_presenter.barcodes&.first
     table_data.push(['Barcode:', barcode]) if barcode.present?
 
-    table_data.push(['Date Printed:', Time.zone.now.strftime('%c')])
+    table_data.push(['Date Printed:', format_datetime(Time.zone.now)])
     table_data
   end
 

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -30,7 +30,8 @@
 en:
   time:
     formats:
-      long: "%B %d, %Y %I:%M %p"
+      date_only: "%Y-%m-%d"
+      date_time: "%Y-%m-%d %H:%M:%S PT"
   errors:
     not_authorized: 'You are not authorized to perform the requested action.'
   release_tags:

--- a/spec/components/bulk_actions/history_section_component_spec.rb
+++ b/spec/components/bulk_actions/history_section_component_spec.rb
@@ -9,7 +9,10 @@ RSpec.describe BulkActions::HistorySectionComponent, type: :component do
     described_class.new(bulk_actions: [bulk_action, bulk_action_with_files])
   end
 
-  let(:bulk_action) { create(:bulk_action, action_type: :reindex, description: 'Test description') }
+  let(:bulk_action) do
+    create(:bulk_action, action_type: :reindex, description: 'Test description',
+                         created_at: Time.zone.parse('2026-04-16T10:00:00Z'))
+  end
   let(:bulk_action_with_files) do
     create(:bulk_action, :with_log, :with_export,
            action_type: :export_cocina_json,
@@ -28,6 +31,7 @@ RSpec.describe BulkActions::HistorySectionComponent, type: :component do
     expect(table).to have_css('tbody tr', count: 2)
 
     bulk_action_row = table.find("tr##{dom_id(bulk_action, 'row')}")
+    expect(bulk_action_row).to have_css('td:nth-of-type(1)', text: '2026-04-16 03:00:00 PT')
     expect(bulk_action_row).to have_css('td:nth-of-type(2)', text: BulkActions::REINDEX.label)
     expect(bulk_action_row).to have_css('td:nth-of-type(3)', text: 'Test description')
     expect(bulk_action_row).to have_css('td:nth-of-type(4)', text: 'Created')

--- a/spec/components/show/workflow_table_component_spec.rb
+++ b/spec/components/show/workflow_table_component_spec.rb
@@ -4,10 +4,6 @@ require 'rails_helper'
 
 RSpec.describe Show::WorkflowTableComponent, type: :component do
   let(:component) { described_class.new(workflow:, version: 2, processes:) }
-  let(:formatted_datetime) do
-    I18n.l(Time.zone.parse(first_process.datetime).in_time_zone('Pacific Time (US & Canada)'), format: :long)
-  end
-
   let(:workflow) { instance_double(Dor::Services::Response::Workflow, workflow_name: 'accessionWF') }
   let(:first_process) do
     instance_double(Dor::Services::Response::Process,
@@ -43,7 +39,7 @@ RSpec.describe Show::WorkflowTableComponent, type: :component do
     expect(page).to have_css('th', text: 'Elapsed')
     expect(page).to have_css('tbody tr', text: 'accessioning-init')
     expect(page).to have_css('tbody tr', text: 'completed')
-    expect(page).to have_text('April 16, 2026 03:00')
+    expect(page).to have_text('2026-04-16 03:00:00 PT')
     expect(page).to have_text('2 minutes')
     expect(page).to have_css('td.text-danger', text: 'Error: Something went wrong')
     expect(page).to have_css('td.text-success-emphasis', text: 'Note: Retry queued')

--- a/spec/jobs/bulk_actions/druids_job_spec.rb
+++ b/spec/jobs/bulk_actions/druids_job_spec.rb
@@ -3,6 +3,8 @@
 require 'rails_helper'
 
 RSpec.describe BulkActions::DruidsJob do
+  include ActiveSupport::Testing::TimeHelpers
+
   # Setting count fields to ensure that they are reset.
   let(:bulk_action) { create(:bulk_action, druid_count_success: 100, druid_count_fail: 100, druid_count_total: 100) }
   let(:druids) { %w[druid:bb111cc2222 druid:cc111dd2222] }
@@ -10,6 +12,8 @@ RSpec.describe BulkActions::DruidsJob do
   let(:export_file) { instance_double(File, close: true) }
 
   before do
+    travel_to(Time.zone.parse('2026-07-29 21:56:58 UTC'))
+
     bulk_action_job_class = Class.new(described_class)
     stub_const('TestBulkActionJob', bulk_action_job_class)
 
@@ -44,7 +48,8 @@ RSpec.describe BulkActions::DruidsJob do
       expect(TestBulkActionJob::JobItem).to have_received(:new).with(druid: druids.second, index: 1,
                                                                      job: instance_of(TestBulkActionJob))
 
-      expect(log).to have_received(:puts).with(/Starting TestBulkActionJob for BulkAction #{bulk_action.id}/)
+      expect(log).to have_received(:puts)
+        .with("2026-07-29 14:56:58 PT Starting TestBulkActionJob for BulkAction #{bulk_action.id}")
       expect(log).to have_received(:puts).with(/Finished TestBulkActionJob for BulkAction #{bulk_action.id}/)
       expect(log).to have_received(:puts).with(/Success: Testing successful for #{druids.first}/o)
       expect(log).to have_received(:puts).with(/Error: Testing failed for #{druids.second}/o)

--- a/spec/presenters/cocina_models/dro_presenter_spec.rb
+++ b/spec/presenters/cocina_models/dro_presenter_spec.rb
@@ -75,7 +75,7 @@ RSpec.describe CocinaModels::DroPresenter do
       let(:embargo_download) { 'none' }
 
       it 'returns the embargo date with view and download values' do
-        expect(presenter.embargo).to eq('June 01, 2026 12:00 AM - View: World, Download: None')
+        expect(presenter.embargo).to eq('2026-06-01 - View: World, Download: None')
       end
     end
 
@@ -87,7 +87,7 @@ RSpec.describe CocinaModels::DroPresenter do
       let(:embargo_location) { 'stanford' }
 
       it 'appends the location to the embargo view access' do
-        expect(presenter.embargo).to eq('June 01, 2026 12:00 AM - View: Location (stanford), Download: None')
+        expect(presenter.embargo).to eq('2026-06-01 - View: Location (stanford), Download: None')
       end
     end
 
@@ -99,7 +99,7 @@ RSpec.describe CocinaModels::DroPresenter do
       let(:embargo_location) { 'stanford' }
 
       it 'appends the location to the embargo download access' do
-        expect(presenter.embargo).to eq('June 01, 2026 12:00 AM - View: Stanford, Download: Location (stanford)')
+        expect(presenter.embargo).to eq('2026-06-01 - View: Stanford, Download: Location (stanford)')
       end
     end
   end

--- a/spec/services/tracksheet_service_spec.rb
+++ b/spec/services/tracksheet_service_spec.rb
@@ -3,6 +3,8 @@
 require 'rails_helper'
 
 RSpec.describe TracksheetService do
+  include ActiveSupport::Testing::TimeHelpers
+
   let(:druid) { 'druid:bc123df4567' }
   let(:solr_doc) { { Search::Fields::ID => druid, Search::Fields::TITLE => title } }
   let(:presenter) { SolrDocPresenter.new(solr_doc:) }
@@ -110,8 +112,10 @@ RSpec.describe TracksheetService do
       end
     end
 
-    it 'always includes a date printed row' do
-      expect(call.map(&:first)).to include('Date Printed:')
+    it 'includes the date printed in Pacific Time' do
+      travel_to(Time.zone.parse('2026-07-29 21:56:58 UTC')) do
+        expect(call).to include(['Date Printed:', '2026-07-29 14:56:58 PT'])
+      end
     end
   end
 end

--- a/spec/system/show_item_spec.rb
+++ b/spec/system/show_item_spec.rb
@@ -247,7 +247,7 @@ RSpec.describe 'Show item' do
     expect(page).to have_table_caption('access-table', 'Access')
     expect(page).to have_table_value('access-table', 'Access rights', 'View: Dark, Download: None')
     expect(page).to have_table_value('access-table', 'License', 'https://creativecommons.org/licenses/by/4.0/legalcode')
-    expect(page).to have_table_value('access-table', 'Embargo', 'June 15, 2040 12:00 PM - View: World, Download: World')
+    expect(page).to have_table_value('access-table', 'Embargo', '2040-06-15 - View: World, Download: World')
 
     # Use and reproduction / Copyright cards
     within('.card', text: 'Use and reproduction') do
@@ -288,7 +288,7 @@ RSpec.describe 'Show item' do
       cells = row.all('td')
       expect(cells[0]).to have_text('described')
       expect(cells[1]).to have_text('skipped')
-      expect(cells[2]).to have_text('June 21, 2023 10:36')
+      expect(cells[2]).to have_text('2023-06-21 10:36:19 PT')
       expect(cells[3]).to have_text('less than a minute')
       expect(page).to have_css('td.text-success-emphasis', text: 'Note: No descMetadata.xml was provided')
 
@@ -323,17 +323,17 @@ RSpec.describe 'Show item' do
     cells = row.all('td')
     expect(cells[0]).to have_text('Initial version')
     expect(cells[1]).to have_text('')
-    expect(cells[2]).to have_text('February 28, 2020 12:23 PM')
-    expect(cells[3]).to have_text('February 28, 2020 12:23 PM')
-    expect(cells[4]).to have_text('February 28, 2020 01:02 PM')
+    expect(cells[2]).to have_text('2020-02-28 12:23:30 PT')
+    expect(cells[3]).to have_text('2020-02-28 12:23:35 PT')
+    expect(cells[4]).to have_text('2020-02-28 13:02:03 PT')
 
     row = find_table_row('versions-table', '2')
     cells = row.all('td')
     expect(cells[0]).to have_text('Second version')
     expect(cells[1]).to have_text('1')
-    expect(cells[2]).to have_text('March 31, 2021 01:23 PM')
-    expect(cells[3]).to have_text('March 31, 2021 01:23 PM')
-    expect(cells[4]).to have_text('March 31, 2021 02:02 PM')
+    expect(cells[2]).to have_text('2021-03-31 13:23:30 PT')
+    expect(cells[3]).to have_text('2021-03-31 13:23:35 PT')
+    expect(cells[4]).to have_text('2021-03-31 14:02:03 PT')
 
     # Files tab
     click_button 'Files'


### PR DESCRIPTION
Fixes #255 - consistent and two different time zone formats

Note: Claude assisted code and specs.

Some examples of date format.  Note the display of "PT" with date/time can cause wrapping


<img width="1066" height="614" alt="Screenshot 2026-08-21 at 11 50 15 AM" src="https://github.com/user-attachments/assets/f65ccc13-f79d-41f2-ab8a-f318b8747b1b" />


<img width="1250" height="319" alt="Screenshot 2026-08-21 at 11 50 50 AM" src="https://github.com/user-attachments/assets/4f91dbb9-01e9-4024-ae31-e2ff46bd98fa" />
