### PR TITLE
Handle admin permission creation in specs

### DIFF
--- a/spec/support/authentication_helpers.rb
+++ b/spec/support/authentication_helpers.rb
@@ -28,5 +28,9 @@ module AuthenticationHelpers
   RSpec.configure do |config|
     config.include AuthenticationHelpers, type: :system
     config.include AuthenticationHelpers, type: :request
+
+    config.before do
+      create(:permission, :admin, workgroup: ADMIN_GROUP)
+    end
   end
 end


### PR DESCRIPTION
If we don't create an admin permission at the start of running specs, then the memoization of admin workgroups in `application_policy.rb` means that later specs that create a permission for testing admin permissions can still fail.

https://github.com/sul-dlss/argo-b3/blob/d178a9c00e7e98a6bb6892897245d520833619a3/app/policies/application_policy.rb#L21

Alternatively, we could create the admin permission at the top of every spec file where it's relevant, or not memoize. Creating it within an individual example can fail because the new permission won't get picked up. 