### PR TITLE
add overtab tab info for DROs

### DIFF
--- a/app/services/search/fields.rb
+++ b/app/services/search/fields.rb
@@ -26,6 +26,7 @@ module Search
     FILE_ROLES = 'content_file_roles_ssimdv'
     FIRST_SHELVED_IMAGE = 'first_shelved_image_ss'
     FORMATS = 'format_ssimdv'
+    FORMATTED_DEPOSITED_LATEST_DATE = 'formatted_deposited_latest_ss'
     FORMATTED_EARLIEST_ACCESSIONED_DATE = 'formatted_accessioned_earliest_ss'
     FORMATTED_EMBARGO_RELEASE_DATE = 'formatted_embargo_release_ss'
     FORMATTED_PUBLISHED_EARLIEST_DATE = 'formatted_published_earliest_ss'

--- a/app/views/objects/show_dro_overview.html.erb
+++ b/app/views/objects/show_dro_overview.html.erb
@@ -1,35 +1,37 @@
 <%= turbo_frame_tag(@solr_doc.druid, 'overview') do %>
-  <div class="row mb-5">
-    <div class="col-xl-6 col-12">
-      <%= render SdrViewComponents::Tables::TableComponent.new(id: 'overview-table-left', classes: 'mb-0 mb-xl-3 split-table') do |component| %>
-        <% component.with_caption do %><%= render SdrViewComponents::Elements::HeadingComponent.new(level: :h2, classes: 'mb-3', text: 'Overview') %><% end %>
-        <% component.with_row(label: 'Object type', value: @solr_doc.object_type.titleize) %>
-        <% component.with_row(label: 'Content type', value: @solr_doc.content_type.titleize) %>
-      <% end %>
-    </div>
+  <%= render SdrViewComponents::Tables::TableComponent.new(id: 'overview-table', classes: 'mb-5') do |component| %>
+    <% component.with_caption do %><%= render SdrViewComponents::Elements::HeadingComponent.new(level: :h2, classes: 'mb-3', text: 'Overview') %><% end %>
+    <% component.with_row(label: 'Druid', value: @solr_doc.bare_druid) %>
+    <% component.with_row(label: 'Content type', value: @solr_doc.content_type.titleize) %>
+    <% component.with_row(label: 'Status', value: @solr_doc.status) %>
+    <% component.with_row(label: 'Preservation size', value: @solr_doc.human_preserved_size) %>
+    <% component.with_row(label: 'Registered', value: format_datetime(@solr_doc.formatted_registered_earliest_date, format: :date_time)) %>
+    <% component.with_row(label: 'Last deposited', value: format_datetime(@solr_doc.formatted_deposited_latest_date, format: :date_time)) %>
+  <% end %>
 
-    <div class="col-xl-6 col-12">
-      <%= render SdrViewComponents::Tables::TableComponent.new(id: 'overview-table-right', classes: 'split-table split-table-right') do |component| %>
-        <% component.with_caption do %><%= render SdrViewComponents::Elements::HeadingComponent.new(level: :h2, classes: 'mb-3 invisible d-none d-xl-block', text: 'Overview, continued', 'aria-hidden': true) %><% end %>
-        <% component.with_row(label: 'Admin policy') do |row_component| %>
-          <% row_component.with_cell do %>
-            <%= link_to @solr_doc.apo_title, object_path(druid: @solr_doc.apo_druid) %>
-            <% search_form = SearchForm.new(admin_policy_titles: [@solr_doc.apo_title]) %>
-            (<%= link_to('All objects with this APO', search_path(search_form.attributes)) %>)
-          <% end %>
-        <% end %>
-        <% component.with_row(label: 'Collection') do |row_component| %>
-          <% row_component.with_cell do %>
-            <% @solr_doc.collection_druids.each_with_index do |collection_druid, index| %>
-              <%= link_to @solr_doc.collection_titles[index], object_path(druid: collection_druid) %>
-              <% search_form = SearchForm.new(collection_titles: [@solr_doc.collection_titles[index]]) %>
-              (<%= link_to('All objects with this collection', search_path(search_form.attributes)) %>)
-            <% end %>
-          <% end %>
+  <%= render SdrViewComponents::Tables::TableComponent.new(id: 'apo-collection-rights-table', classes: 'mb-5') do |component| %>
+    <% component.with_caption do %><%= render SdrViewComponents::Elements::HeadingComponent.new(level: :h2, classes: 'mb-3', text: 'APO, Collection, Rights') %><% end %>
+    <% component.with_row(label: 'Admin policy') do |row_component| %>
+      <% row_component.with_cell do %>
+        <%= link_to @solr_doc.apo_title, object_path(druid: @solr_doc.apo_druid) %>
+        <% search_form = SearchForm.new(admin_policy_titles: [@solr_doc.apo_title]) %>
+        (<%= link_to('All objects with this APO', search_path(search_form.attributes)) %>)
+      <% end %>
+    <% end %>
+    <% component.with_row(label: 'Collection') do |row_component| %>
+      <% row_component.with_cell do %>
+        <% Array(@solr_doc.collection_druids).each_with_index do |collection_druid, index| %>
+          <% collection_title = Array(@solr_doc.collection_titles)[index] %>
+          <%= link_to collection_title, object_path(druid: collection_druid) %>
+          <% search_form = SearchForm.new(collection_titles: [collection_title]) %>
+          (<%= link_to('All objects with this collection', search_path(search_form.attributes)) %>)
         <% end %>
       <% end %>
-    </div>
-  </div>
+    <% end %>
+    <% component.with_row(label: 'Access rights', value: @cocina_model.display_access_rights) %>
+    <% component.with_row(label: 'Embargo', value: @cocina_model.embargo) %>
+    <% component.with_row(label: 'License', value: @cocina_model.license) %>
+  <% end %>
 
   <%= render SdrViewComponents::Tables::TableComponent.new(id: 'identification-table', classes: 'mb-5') do |component| %>
     <% component.with_caption do %><%= render SdrViewComponents::Elements::HeadingComponent.new(level: :h2, classes: 'mb-3', text: 'Identification') %><% end %>
@@ -40,11 +42,12 @@
     <% component.with_row(label: 'DOI', value: @solr_doc.doi) %>
   <% end %>
 
-  <%= render SdrViewComponents::Tables::TableComponent.new(id: 'access-table', classes: 'mb-5') do |component| %>
-    <% component.with_caption do %><%= render SdrViewComponents::Elements::HeadingComponent.new(level: :h2, classes: 'mb-3', text: 'Access') %><% end %>
-    <% component.with_row(label: 'Access rights', value: @cocina_model.display_access_rights) %>
-    <% component.with_row(label: 'Embargo', value: @cocina_model.embargo) %>
-    <% component.with_row(label: 'License', value: @cocina_model.license) %>
+  <% if @cocina_model.catalog_link_part_label.present? || @cocina_model.catalog_link_sort_key.present? %>
+    <%= render SdrViewComponents::Tables::TableComponent.new(id: 'folio-table', classes: 'mb-5') do |component| %>
+      <% component.with_caption do %><%= render SdrViewComponents::Elements::HeadingComponent.new(level: :h2, classes: 'mb-3', text: 'Folio') %><% end %>
+      <% component.with_row(label: 'Part label', value: @cocina_model.catalog_link_part_label) %>
+      <% component.with_row(label: 'Sort key', value: @cocina_model.catalog_link_sort_key) %>
+    <% end %>
   <% end %>
 
   <div class="use-access-copyright-section d-flex flex-column flex-xl-row gap-5 px-xl-5 mt-4 mb-5">

--- a/app/views/objects/show_dro_overview.html.erb
+++ b/app/views/objects/show_dro_overview.html.erb
@@ -6,7 +6,9 @@
     <% component.with_row(label: 'Status', value: @solr_doc.status) %>
     <% component.with_row(label: 'Preservation size', value: @solr_doc.human_preserved_size) %>
     <% component.with_row(label: 'Registered', value: format_datetime(@solr_doc.formatted_registered_earliest_date, format: :date_time)) %>
-    <% component.with_row(label: 'Last deposited', value: format_datetime(@solr_doc.formatted_deposited_latest_date, format: :date_time)) %>
+    <% if @solr_doc.formatted_deposited_latest_date.present? %>
+      <% component.with_row(label: 'Last deposited', value: format_datetime(@solr_doc.formatted_deposited_latest_date, format: :date_time)) %>
+    <% end %>
   <% end %>
 
   <%= render SdrViewComponents::Tables::TableComponent.new(id: 'apo-collection-rights-table', classes: 'mb-5') do |component| %>
@@ -42,11 +44,15 @@
     <% component.with_row(label: 'DOI', value: @solr_doc.doi) %>
   <% end %>
 
-  <% if @cocina_model.catalog_link_part_label.present? || @cocina_model.catalog_link_sort_key.present? %>
+  <%# NOTE: A Cocina object can have a partLabel without a sortKey. %>
+  <%# A sortKey should always have a partLabel. %>
+  <% if @cocina_model.catalog_link_part_label.present? %>
     <%= render SdrViewComponents::Tables::TableComponent.new(id: 'folio-table', classes: 'mb-5') do |component| %>
-      <% component.with_caption do %><%= render SdrViewComponents::Elements::HeadingComponent.new(level: :h2, classes: 'mb-3', text: 'Folio') %><% end %>
+      <% component.with_caption do %><%= render SdrViewComponents::Elements::HeadingComponent.new(level: :h2, classes: 'mb-3', text: 'Serials') %><% end %>
       <% component.with_row(label: 'Part label', value: @cocina_model.catalog_link_part_label) %>
-      <% component.with_row(label: 'Sort key', value: @cocina_model.catalog_link_sort_key) %>
+      <% if @cocina_model.catalog_link_sort_key.present? %>
+        <% component.with_row(label: 'Sort key', value: @cocina_model.catalog_link_sort_key) %>
+      <% end %>
     <% end %>
   <% end %>
 

--- a/app/views/objects/show_dro_overview.html.erb
+++ b/app/views/objects/show_dro_overview.html.erb
@@ -47,7 +47,7 @@
   <%# NOTE: A Cocina object can have a partLabel without a sortKey. %>
   <%# A sortKey should always have a partLabel. %>
   <% if @cocina_model.catalog_link_part_label.present? %>
-    <%= render SdrViewComponents::Tables::TableComponent.new(id: 'folio-table', classes: 'mb-5') do |component| %>
+    <%= render SdrViewComponents::Tables::TableComponent.new(id: 'serials-table', classes: 'mb-5') do |component| %>
       <% component.with_caption do %><%= render SdrViewComponents::Elements::HeadingComponent.new(level: :h2, classes: 'mb-3', text: 'Serials') %><% end %>
       <% component.with_row(label: 'Part label', value: @cocina_model.catalog_link_part_label) %>
       <% if @cocina_model.catalog_link_sort_key.present? %>

--- a/spec/support/authentication_helpers.rb
+++ b/spec/support/authentication_helpers.rb
@@ -30,7 +30,7 @@ module AuthenticationHelpers
     config.include AuthenticationHelpers, type: :request
 
     config.before do
-      create(:permission, :admin, workgroup: ADMIN_GROUP)
+      Permission.find_or_create_by!(workgroup: ADMIN_GROUP, permission_type: :admin)
     end
   end
 end

--- a/spec/system/show_item_spec.rb
+++ b/spec/system/show_item_spec.rb
@@ -73,7 +73,7 @@ RSpec.describe 'Show item' do
     ]
   end
 
-  def build_solr_doc(title:)
+  def build_solr_doc(title:, last_deposited: '2026-07-26')
     {
       Search::Fields::ID => druid,
       Search::Fields::OBJECT_TYPES => ['item'],
@@ -91,7 +91,7 @@ RSpec.describe 'Show item' do
       Search::Fields::STATUS => 'v2 deposited',
       Search::Fields::HUMAN_PRESERVED_SIZE => '30 MB',
       Search::Fields::FORMATTED_REGISTERED_EARLIEST_DATE => '2025-01-08',
-      Search::Fields::FORMATTED_DEPOSITED_LATEST_DATE => '2026-07-26',
+      Search::Fields::FORMATTED_DEPOSITED_LATEST_DATE => last_deposited,
       Search::Fields::OTHER_TAGS => ['Registered By : jdoe', 'Remediated By : labtech'],
       Search::Fields::TICKETS => ['TESTREQ-1']
     }
@@ -273,7 +273,7 @@ RSpec.describe 'Show item' do
                                      '2040-06-15 - View: World, Download: World')
 
     # Folio table
-    expect(page).to have_table_caption('folio-table', 'Folio')
+    expect(page).to have_table_caption('folio-table', 'Serials')
     expect(page).to have_table_value('folio-table', 'Part label', 'Part 1')
     expect(page).to have_table_value('folio-table', 'Sort key', '001')
 
@@ -384,7 +384,8 @@ RSpec.describe 'Show item' do
                               href: "https://purl.stanford.edu/#{DruidSupport.bare_druid_from(druid)}", count: 2)
 
     # Update the object and look for changes.
-    allow(Sdr::Repository).to receive(:find_solr).and_return(build_solr_doc(title: updated_title))
+    allow(Sdr::Repository).to receive(:find_solr)
+      .and_return(build_solr_doc(title: updated_title, last_deposited: nil))
     allow(Sdr::Repository).to receive(:find)
       .and_return(build_cocina_object(title: updated_title,
                                       access: {
@@ -394,7 +395,7 @@ RSpec.describe 'Show item' do
                                         license: 'https://creativecommons.org/publicdomain/zero/1.0/legalcode',
                                         useAndReproductionStatement: 'My updated use statement'
                                       },
-                                      part_label: nil,
+                                      part_label: 'Part 2',
                                       sort_key: nil))
     allow(Sdr::WorkflowService).to receive(:workflows_for).and_return([registration_workflow,
                                                                        build_accession_workflow(complete: true)])
@@ -402,9 +403,11 @@ RSpec.describe 'Show item' do
     expect(page).to have_css('h1', text: updated_title, wait: 15)
 
     click_button 'Overview'
+    expect(find_table('overview-table')).to have_no_css('th', text: 'Last deposited')
     expect(page).to have_table_value('apo-collection-rights-table', 'Access rights', 'View: World, Download: World')
     expect(page).to have_table_value('apo-collection-rights-table', 'License', 'https://creativecommons.org/publicdomain/zero/1.0/legalcode')
-    expect(page).to have_no_table('folio-table')
+    expect(page).to have_table_value('folio-table', 'Part label', 'Part 2')
+    expect(find_table('folio-table')).to have_no_css('th', text: 'Sort key')
     within('.card', text: 'Use and reproduction') do
       expect(page).to have_css('.card-text', text: 'My updated use statement')
     end

--- a/spec/system/show_item_spec.rb
+++ b/spec/system/show_item_spec.rb
@@ -266,12 +266,11 @@ RSpec.describe 'Show item' do
     expect(page).to have_table_value('identification-table', 'Barcode', 'bb123cd4567')
     expect(page).to have_table_value('identification-table', 'DOI', 'https://doi.org/10.5072/bb123cd4567')
 
-    # Access table
-    expect(page).to have_table_caption('access-table', 'Access')
-    expect(page).to have_table_value('access-table', 'Access rights', 'View: Dark, Download: None')
-    expect(page).to have_table_value('access-table', 'License', 'https://creativecommons.org/licenses/by/4.0/legalcode')
-    expect(page).to have_table_value('access-table', 'Embargo',
-                                     'June 15, 2040 12:00 PM - View: World, Download: World')
+    # Access rows
+    expect(page).to have_table_value('apo-collection-rights-table', 'Access rights', 'View: Dark, Download: None')
+    expect(page).to have_table_value('apo-collection-rights-table', 'License', 'https://creativecommons.org/licenses/by/4.0/legalcode')
+    expect(page).to have_table_value('apo-collection-rights-table', 'Embargo',
+                                     '2040-06-15 - View: World, Download: World')
 
     # Folio table
     expect(page).to have_table_caption('folio-table', 'Folio')

--- a/spec/system/show_item_spec.rb
+++ b/spec/system/show_item_spec.rb
@@ -88,17 +88,33 @@ RSpec.describe 'Show item' do
       Search::Fields::BARCODES => ['bb123cd4567'],
       Search::Fields::DOI => 'https://doi.org/10.5072/bb123cd4567',
       Search::Fields::CONTENT_TYPES => ['book'],
+      Search::Fields::STATUS => 'v2 deposited',
+      Search::Fields::HUMAN_PRESERVED_SIZE => '30 MB',
+      Search::Fields::FORMATTED_REGISTERED_EARLIEST_DATE => '2025-01-08',
+      Search::Fields::FORMATTED_DEPOSITED_LATEST_DATE => '2026-07-26',
       Search::Fields::OTHER_TAGS => ['Registered By : jdoe', 'Remediated By : labtech'],
       Search::Fields::TICKETS => ['TESTREQ-1']
     }
   end
 
-  def build_cocina_object(title:, access: {})
+  def build_cocina_object(title:, access: {}, part_label: 'Part 1', sort_key: '001')
     file_access = { view: access.fetch(:view, 'dark'), download: access.fetch(:download, 'none') }
     file_shelve = file_access[:view] != 'dark'
 
     build(:dro_with_metadata, id: druid, admin_policy_id: apo_druid)
       .new(
+        identification: {
+          sourceId: 'googlebooks:stanford_36105114203446',
+          catalogLinks: [
+            {
+              catalog: 'folio',
+              catalogRecordId: 'a6525053',
+              refresh: true,
+              partLabel: part_label,
+              sortKey: sort_key
+            }.compact
+          ]
+        },
         structural: {
           isMemberOf: [collection_druid],
           contains: [
@@ -215,15 +231,22 @@ RSpec.describe 'Show item' do
     expect(page).to have_css('.nav-link', text: 'Description Preview')
 
     # Overview table
-    expect(page).to have_table_caption('overview-table-left', 'Overview')
-    expect(page).to have_table_value('overview-table-left', 'Object type', 'Item')
-    expect(page).to have_table_value('overview-table-left', 'Content type', 'Book')
-    within(find_table_value_cell('overview-table-right', 'Admin policy')) do
+    expect(page).to have_table_caption('overview-table', 'Overview')
+    expect(page).to have_table_value('overview-table', 'Druid', 'bb123cd4567')
+    expect(page).to have_table_value('overview-table', 'Content type', 'Book')
+    expect(page).to have_table_value('overview-table', 'Status', 'v2 deposited')
+    expect(page).to have_table_value('overview-table', 'Preservation size', '30 MB')
+    expect(page).to have_table_value('overview-table', 'Registered', '2025-01-08')
+    expect(page).to have_table_value('overview-table', 'Last deposited', '2026-07-26')
+
+    # APO, Collection, Rights table
+    expect(page).to have_table_caption('apo-collection-rights-table', 'APO, Collection, Rights')
+    within(find_table_value_cell('apo-collection-rights-table', 'Admin policy')) do
       expect(page).to have_link('My APO', href: "/objects/#{apo_druid}")
       expect(page).to have_link('All objects with this APO',
                                 href: '/search?admin_policy_titles%5B%5D=My+APO&page=1')
     end
-    within(find_table_value_cell('overview-table-right', 'Collection')) do
+    within(find_table_value_cell('apo-collection-rights-table', 'Collection')) do
       expect(page).to have_link('My Collection', href: "/objects/#{collection_druid}")
       expect(page).to have_link('All objects with this collection',
                                 href: '/search?collection_titles%5B%5D=My+Collection&page=1')
@@ -247,7 +270,13 @@ RSpec.describe 'Show item' do
     expect(page).to have_table_caption('access-table', 'Access')
     expect(page).to have_table_value('access-table', 'Access rights', 'View: Dark, Download: None')
     expect(page).to have_table_value('access-table', 'License', 'https://creativecommons.org/licenses/by/4.0/legalcode')
-    expect(page).to have_table_value('access-table', 'Embargo', '2040-06-15 - View: World, Download: World')
+    expect(page).to have_table_value('access-table', 'Embargo',
+                                     'June 15, 2040 12:00 PM - View: World, Download: World')
+
+    # Folio table
+    expect(page).to have_table_caption('folio-table', 'Folio')
+    expect(page).to have_table_value('folio-table', 'Part label', 'Part 1')
+    expect(page).to have_table_value('folio-table', 'Sort key', '001')
 
     # Use and reproduction / Copyright cards
     within('.card', text: 'Use and reproduction') do
@@ -358,21 +387,25 @@ RSpec.describe 'Show item' do
     # Update the object and look for changes.
     allow(Sdr::Repository).to receive(:find_solr).and_return(build_solr_doc(title: updated_title))
     allow(Sdr::Repository).to receive(:find)
-      .and_return(build_cocina_object(title: updated_title, access: {
+      .and_return(build_cocina_object(title: updated_title,
+                                      access: {
                                         view: 'world',
                                         download: 'world',
                                         copyright: 'My updated copyright statement',
                                         license: 'https://creativecommons.org/publicdomain/zero/1.0/legalcode',
                                         useAndReproductionStatement: 'My updated use statement'
-                                      }))
+                                      },
+                                      part_label: nil,
+                                      sort_key: nil))
     allow(Sdr::WorkflowService).to receive(:workflows_for).and_return([registration_workflow,
                                                                        build_accession_workflow(complete: true)])
 
     expect(page).to have_css('h1', text: updated_title, wait: 15)
 
     click_button 'Overview'
-    expect(page).to have_table_value('access-table', 'Access rights', 'View: World, Download: World')
-    expect(page).to have_table_value('access-table', 'License', 'https://creativecommons.org/publicdomain/zero/1.0/legalcode')
+    expect(page).to have_table_value('apo-collection-rights-table', 'Access rights', 'View: World, Download: World')
+    expect(page).to have_table_value('apo-collection-rights-table', 'License', 'https://creativecommons.org/publicdomain/zero/1.0/legalcode')
+    expect(page).to have_no_table('folio-table')
     within('.card', text: 'Use and reproduction') do
       expect(page).to have_css('.card-text', text: 'My updated use statement')
     end

--- a/spec/system/show_item_spec.rb
+++ b/spec/system/show_item_spec.rb
@@ -273,9 +273,9 @@ RSpec.describe 'Show item' do
                                      '2040-06-15 - View: World, Download: World')
 
     # Folio table
-    expect(page).to have_table_caption('folio-table', 'Serials')
-    expect(page).to have_table_value('folio-table', 'Part label', 'Part 1')
-    expect(page).to have_table_value('folio-table', 'Sort key', '001')
+    expect(page).to have_table_caption('serials-table', 'Serials')
+    expect(page).to have_table_value('serials-table', 'Part label', 'Part 1')
+    expect(page).to have_table_value('serials-table', 'Sort key', '001')
 
     # Use and reproduction / Copyright cards
     within('.card', text: 'Use and reproduction') do
@@ -406,8 +406,8 @@ RSpec.describe 'Show item' do
     expect(find_table('overview-table')).to have_no_css('th', text: 'Last deposited')
     expect(page).to have_table_value('apo-collection-rights-table', 'Access rights', 'View: World, Download: World')
     expect(page).to have_table_value('apo-collection-rights-table', 'License', 'https://creativecommons.org/publicdomain/zero/1.0/legalcode')
-    expect(page).to have_table_value('folio-table', 'Part label', 'Part 2')
-    expect(find_table('folio-table')).to have_no_css('th', text: 'Sort key')
+    expect(page).to have_table_value('serials-table', 'Part label', 'Part 2')
+    expect(find_table('serials-table')).to have_no_css('th', text: 'Sort key')
     within('.card', text: 'Use and reproduction') do
       expect(page).to have_css('.card-text', text: 'My updated use statement')
     end


### PR DESCRIPTION
Fixes #258 - adds info for overview tab

* ~~The date display fields may need to updated to match our new consistent format options based on #388 when that is merged.~~
* Multi-column layout removed, but css styles remain in case we need them again.

<img width="1002" height="437" alt="Screenshot 2026-08-24 at 8 56 50 AM" src="https://github.com/user-attachments/assets/e8afcd95-74fe-4fed-8879-0661ef455f47" />


Claude assisted code and specs

