### PR TITLE
show embargo banner for embargoed items

### DIFF
--- a/app/assets/stylesheets/show.scss
+++ b/app/assets/stylesheets/show.scss
@@ -1,7 +1,10 @@
 // Object show page
 .object-show {
   .embargo-banner {
-    margin-inline: calc(50% - 50vw);
+    position: relative;
+    left: 50%;
+    width: 100vw;
+    transform: translateX(-50%);
   }
 
   .show-box {

--- a/app/assets/stylesheets/show.scss
+++ b/app/assets/stylesheets/show.scss
@@ -1,5 +1,9 @@
 // Object show page
 .object-show {
+  .embargo-banner {
+    margin-inline: calc(50% - 50vw);
+  }
+
   .show-box {
     max-width: 300px;
 

--- a/app/assets/stylesheets/show.scss
+++ b/app/assets/stylesheets/show.scss
@@ -1,10 +1,17 @@
 // Object show page
 .object-show {
   .embargo-banner {
+    display: flex;
+    align-items: center;
+    justify-content: center;
     position: relative;
     left: 50%;
     width: 100vw;
     transform: translateX(-50%);
+
+    h2 {
+      margin-bottom: 0;
+    }
   }
 
   .show-box {

--- a/app/components/show/embargo_banner_component.html.erb
+++ b/app/components/show/embargo_banner_component.html.erb
@@ -1,0 +1,4 @@
+<div class="embargo-banner bg-black text-white text-center py-2">
+  Embargoed until <%= formatted_release_date %>
+  <i class="bi bi-pencil ms-1" aria-hidden="true"></i>
+</div>

--- a/app/components/show/embargo_banner_component.html.erb
+++ b/app/components/show/embargo_banner_component.html.erb
@@ -1,4 +1,4 @@
 <div class="embargo-banner bg-black text-white text-center py-2">
-  Embargoed until <%= formatted_release_date %>
-  <i class="bi bi-pencil ms-1" aria-hidden="true"></i>
+  <h2>Embargoed until <%= formatted_release_date %>
+  <i class="bi bi-pencil ms-1" aria-hidden="true"></i></h2>
 </div>

--- a/app/components/show/embargo_banner_component.rb
+++ b/app/components/show/embargo_banner_component.rb
@@ -1,0 +1,25 @@
+# frozen_string_literal: true
+
+module Show
+  # Component for displaying an object's embargo release date on the show page.
+  class EmbargoBannerComponent < ApplicationComponent
+    include ApplicationHelper
+
+    def initialize(release_date:)
+      @release_date = release_date
+      super()
+    end
+
+    def render?
+      release_date.present?
+    end
+
+    def formatted_release_date
+      format_datetime(release_date, format: :date_only)
+    end
+
+    private
+
+    attr_reader :release_date
+  end
+end

--- a/app/views/objects/show.html.erb
+++ b/app/views/objects/show.html.erb
@@ -22,6 +22,8 @@
           <%= render SdrViewComponents::Elements::HeadingComponent.new(level: :h1, text: @solr_doc.title, classes: 'mb-xl-4 mb-3') %>
         <% end %>
       </div>
+
+      <%= render Show::EmbargoBannerComponent.new(release_date: @solr_doc.formatted_embargo_release_date) %>
     <% end %>
 
     <% layout.with_left_content do %>

--- a/spec/components/show/embargo_banner_component_spec.rb
+++ b/spec/components/show/embargo_banner_component_spec.rb
@@ -1,0 +1,27 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe Show::EmbargoBannerComponent, type: :component do
+  subject(:component) { described_class.new(release_date:) }
+
+  let(:release_date) { '2029-01-01 12:00:00 AM' }
+
+  it 'renders a full-width black banner with the release date and pencil icon' do
+    render_inline(component)
+
+    expect(page).to have_css('.embargo-banner.bg-black.text-white', text: 'Embargoed until 2029-01-01')
+    expect(page).to have_css('.embargo-banner > i.bi-pencil')
+    expect(page).to have_no_link
+  end
+
+  context 'without an embargo release date' do
+    let(:release_date) { nil }
+
+    it 'does not render' do
+      render_inline(component)
+
+      expect(page).to have_no_css('.embargo-banner')
+    end
+  end
+end

--- a/spec/components/show/embargo_banner_component_spec.rb
+++ b/spec/components/show/embargo_banner_component_spec.rb
@@ -10,8 +10,8 @@ RSpec.describe Show::EmbargoBannerComponent, type: :component do
   it 'renders a full-width black banner with the release date and pencil icon' do
     render_inline(component)
 
-    expect(page).to have_css('.embargo-banner.bg-black.text-white', text: 'Embargoed until 2029-01-01')
-    expect(page).to have_css('.embargo-banner > i.bi-pencil')
+    expect(page).to have_css('.embargo-banner.bg-black.text-white h2', text: 'Embargoed until 2029-01-01')
+    expect(page).to have_css('.embargo-banner h2 > i.bi-pencil')
     expect(page).to have_no_link
   end
 

--- a/spec/system/show_item_spec.rb
+++ b/spec/system/show_item_spec.rb
@@ -209,8 +209,8 @@ RSpec.describe 'Show item' do
 
     expect(page).to have_css('h1', text: original_title)
     expect(page).to have_css('.object-show.object-type-item .object-type-badge', text: 'ITEM')
-    expect(page).to have_css('.embargo-banner.bg-black.text-white', text: 'Embargoed until 2040-06-15')
-    expect(page).to have_css('.embargo-banner > i.bi-pencil')
+    expect(page).to have_css('.embargo-banner.bg-black.text-white h2', text: 'Embargoed until 2040-06-15')
+    expect(page).to have_css('.embargo-banner h2 > i.bi-pencil')
 
     # Status box
     expect(page).to have_css('h2', text: 'Deposited')

--- a/spec/system/show_item_spec.rb
+++ b/spec/system/show_item_spec.rb
@@ -92,6 +92,7 @@ RSpec.describe 'Show item' do
       Search::Fields::HUMAN_PRESERVED_SIZE => '30 MB',
       Search::Fields::FORMATTED_REGISTERED_EARLIEST_DATE => '2025-01-08',
       Search::Fields::FORMATTED_DEPOSITED_LATEST_DATE => last_deposited,
+      Search::Fields::FORMATTED_EMBARGO_RELEASE_DATE => '2040-06-15 12:00:00 PM',
       Search::Fields::OTHER_TAGS => ['Registered By : jdoe', 'Remediated By : labtech'],
       Search::Fields::TICKETS => ['TESTREQ-1']
     }
@@ -208,6 +209,8 @@ RSpec.describe 'Show item' do
 
     expect(page).to have_css('h1', text: original_title)
     expect(page).to have_css('.object-show.object-type-item .object-type-badge', text: 'ITEM')
+    expect(page).to have_css('.embargo-banner.bg-black.text-white', text: 'Embargoed until 2040-06-15')
+    expect(page).to have_css('.embargo-banner > i.bi-pencil')
 
     # Status box
     expect(page).to have_css('h2', text: 'Deposited')


### PR DESCRIPTION
Fixes #266  - Add embargo banner with date for embargoed items

<img width="1393" height="670" alt="Screenshot 2026-08-24 at 2 55 52 PM" src="https://github.com/user-attachments/assets/71450559-0300-4440-ad0f-5c45781f3c6a" />

Note: single item embargo date editing is not implemented yet, so the pencil is unlinked for now.