### PR TITLE
flail spec fix?

### DIFF
--- a/spec/jobs/bulk_actions/manage_source_id_job_spec.rb
+++ b/spec/jobs/bulk_actions/manage_source_id_job_spec.rb
@@ -33,6 +33,7 @@ RSpec.describe BulkActions::ManageSourceIdJob do
 
   before do
     allow(described_class::JobItem).to receive(:new).and_return(job_item)
+    allow(File).to receive(:open).and_call_original
     allow(File).to receive(:open).with(bulk_action.log_filepath, 'a').and_return(log)
     allow(Sdr::Repository).to receive(:update)
     allow(Dor::Services::Client).to receive(:object).with(druid).and_return(object_client)


### PR DESCRIPTION
Noticed a flailing test, Codex said this:


`The failing spec mocked only the bulk-action log call to File.open, blocking Rails from reading the Pacific timezone file. I added a default and_call_original in [manage_source_id_job_spec.rb (line 36)](/Users/petucket/Sites/development/argo-b3/spec/jobs/bulk_actions/manage_source_id_job_spec.rb:36).`