### PR TITLE
fix flaky specs

### DIFF
--- a/spec/jobs/bulk_actions/apply_apo_defaults_job_spec.rb
+++ b/spec/jobs/bulk_actions/apply_apo_defaults_job_spec.rb
@@ -23,7 +23,9 @@ RSpec.describe BulkActions::ApplyApoDefaultsJob do
 
   before do
     allow(Dor::Services::Client).to receive(:object).with(druid).and_return(object_client)
-    allow(File).to receive(:open).and_return(log)
+
+    allow(File).to receive(:open).and_call_original
+    allow(File).to receive(:open).with(bulk_action.log_filepath, 'a').and_return(log)
 
     allow(described_class::JobItem).to receive(:new).and_return(job_item)
   end

--- a/spec/jobs/bulk_actions/base_csv_job_spec.rb
+++ b/spec/jobs/bulk_actions/base_csv_job_spec.rb
@@ -23,8 +23,8 @@ RSpec.describe BulkActions::BaseCsvJob do
 
     allow(TestBulkActionCsvJob::JobItem).to receive(:new).and_call_original
 
+    allow(File).to receive(:open).and_call_original
     allow(File).to receive(:open).with(bulk_action.log_filepath, 'a').and_return(log)
-    # allow_any_instance_of(BulkAction).to receive(:open_log_file).and_return(log)
   end
 
   after do

--- a/spec/jobs/bulk_actions/druids_job_spec.rb
+++ b/spec/jobs/bulk_actions/druids_job_spec.rb
@@ -18,6 +18,7 @@ RSpec.describe BulkActions::DruidsJob do
     stub_const('TestBulkActionJob', bulk_action_job_class)
 
     allow_any_instance_of(TestBulkActionJob).to receive(:export_file).and_return(export_file) # rubocop:disable RSpec/AnyInstance
+    allow(File).to receive(:open).and_call_original
     allow(File).to receive(:open).with(bulk_action.log_filepath, 'a').and_return(log)
     allow(Turbo::StreamsChannel).to receive(:broadcast_refresh_to)
     allow(Turbo::StreamsChannel).to receive(:broadcast_append_to)

--- a/spec/jobs/bulk_actions/import_catalog_data_job_spec.rb
+++ b/spec/jobs/bulk_actions/import_catalog_data_job_spec.rb
@@ -42,6 +42,7 @@ RSpec.describe BulkActions::ImportCatalogDataJob do
 
   before do
     allow(described_class::JobItem).to receive(:new).and_return(job_item)
+    allow(File).to receive(:open).and_call_original
     allow(File).to receive(:open).with(bulk_action.log_filepath, 'a').and_return(log)
     allow(Sdr::Repository).to receive(:update)
     allow(Dor::Services::Client).to receive(:object).with(druid).and_return(object_client)

--- a/spec/jobs/bulk_actions/manage_content_type_job_spec.rb
+++ b/spec/jobs/bulk_actions/manage_content_type_job_spec.rb
@@ -46,6 +46,7 @@ RSpec.describe BulkActions::ManageContentTypeJob do
 
   before do
     allow(described_class::JobItem).to receive(:new).and_return(job_item)
+    allow(File).to receive(:open).and_call_original
     allow(File).to receive(:open).with(bulk_action.log_filepath, 'a').and_return(log)
     allow(Sdr::Repository).to receive(:find).with(druid:).and_return(cocina_object)
     allow(Sdr::Repository).to receive(:update)

--- a/spec/jobs/bulk_actions/manage_embargo_job_spec.rb
+++ b/spec/jobs/bulk_actions/manage_embargo_job_spec.rb
@@ -34,6 +34,7 @@ RSpec.describe BulkActions::ManageEmbargoJob do
 
   before do
     allow(described_class::JobItem).to receive(:new).and_return(job_item)
+    allow(File).to receive(:open).and_call_original
     allow(File).to receive(:open).with(bulk_action.log_filepath, 'a').and_return(log)
     allow(Sdr::Repository).to receive(:update)
     allow(Dor::Services::Client).to receive(:object).with(druid).and_return(object_client)

--- a/spec/jobs/bulk_actions/manage_license_and_rights_statements_job_spec.rb
+++ b/spec/jobs/bulk_actions/manage_license_and_rights_statements_job_spec.rb
@@ -38,6 +38,7 @@ RSpec.describe BulkActions::ManageLicenseAndRightsStatementsJob do
 
   before do
     allow(described_class::JobItem).to receive(:new).and_return(job_item)
+    allow(File).to receive(:open).and_call_original
     allow(File).to receive(:open).with(bulk_action.log_filepath, 'a').and_return(log)
     allow(Sdr::Repository).to receive(:find).with(druid:).and_return(cocina_object)
     allow(Sdr::Repository).to receive(:update)

--- a/spec/jobs/bulk_actions/manage_release_job_spec.rb
+++ b/spec/jobs/bulk_actions/manage_release_job_spec.rb
@@ -25,6 +25,7 @@ RSpec.describe BulkActions::ManageReleaseJob do
     allow(described_class::JobItem).to receive(:new).and_return(job_item)
     allow(Sdr::WorkflowService).to receive(:published?).and_return(true)
     allow(Sdr::Repository).to receive(:create_release_tag)
+    allow(File).to receive(:open).and_call_original
     allow(File).to receive(:open).with(bulk_action.log_filepath, 'a').and_return(log)
   end
 

--- a/spec/jobs/bulk_actions/manage_rights_job_spec.rb
+++ b/spec/jobs/bulk_actions/manage_rights_job_spec.rb
@@ -29,6 +29,7 @@ RSpec.describe BulkActions::ManageRightsJob do
 
   before do
     allow(described_class::JobItem).to receive(:new).and_return(job_item)
+    allow(File).to receive(:open).and_call_original
     allow(File).to receive(:open).with(bulk_action.log_filepath, 'a').and_return(log)
     allow(Sdr::Repository).to receive(:find).with(druid:).and_return(cocina_object)
     allow(Sdr::Repository).to receive(:update)

--- a/spec/jobs/bulk_actions/manage_source_id_job_spec.rb
+++ b/spec/jobs/bulk_actions/manage_source_id_job_spec.rb
@@ -33,6 +33,7 @@ RSpec.describe BulkActions::ManageSourceIdJob do
 
   before do
     allow(described_class::JobItem).to receive(:new).and_return(job_item)
+    allow(File).to receive(:open).and_call_original
     allow(File).to receive(:open).with(bulk_action.log_filepath, 'a').and_return(log)
     allow(Sdr::Repository).to receive(:update)
     allow(Dor::Services::Client).to receive(:object).with(druid).and_return(object_client)

--- a/spec/jobs/bulk_actions/refresh_metadata_job_spec.rb
+++ b/spec/jobs/bulk_actions/refresh_metadata_job_spec.rb
@@ -29,7 +29,8 @@ RSpec.describe BulkActions::RefreshMetadataJob do
   before do
     allow(described_class::JobItem).to receive(:new).and_return(job_item)
     allow(Dor::Services::Client).to receive(:object).with(druid).and_return(object_client)
-    allow(File).to receive(:open).and_return(log)
+    allow(File).to receive(:open).and_call_original
+    allow(File).to receive(:open).with(bulk_action.log_filepath, 'a').and_return(log)
   end
 
   it 'performs the job' do

--- a/spec/jobs/bulk_actions/reindex_job_spec.rb
+++ b/spec/jobs/bulk_actions/reindex_job_spec.rb
@@ -12,6 +12,7 @@ RSpec.describe BulkActions::ReindexJob do
   let(:object_client) { instance_double(Dor::Services::Client::Object, reindex: true) }
 
   before do
+    allow(File).to receive(:open).and_call_original
     allow(File).to receive(:open).with(bulk_action.log_filepath, 'a').and_return(log)
     allow(Dor::Services::Client).to receive(:object).and_return(object_client)
   end


### PR DESCRIPTION
This matches what we do in other bulk job specs (e.g. see https://github.com/sul-dlss/argo-b3/blob/main/spec/jobs/bulk_actions/export_catalog_data_job_spec.rb#L27-L29).  If you don't do this, you can end up with failures due to date formatting depending on the ordering of tests that are run and if they are run in parallel or not.  something something mocking timezone loading mocking something something

