### PR TITLE
change ordering/wording of show page tabs

### DIFF
--- a/app/views/objects/show.html.erb
+++ b/app/views/objects/show.html.erb
@@ -79,12 +79,13 @@
         <% component.with_tab(id: 'overview-tab', pane_id: 'overview-pane', label: 'Overview', active: true) %>
         <% component.with_tab(id: 'purl-preview-tab', pane_id: 'purl-preview-pane', label: 'Description Preview') if @solr_doc.dro_or_collection? %>
         <% component.with_tab(id: 'files-tab', pane_id: 'files-pane', label: 'Files') if @solr_doc.dro? %>
-        <% component.with_tab(id: 'workflows-tab', pane_id: 'workflows-pane', label: 'Workflows') %>
-        <% component.with_tab(id: 'versions-tab', pane_id: 'versions-pane', label: 'Versions') %>
+        <% component.with_tab(id: 'history-tab', pane_id: 'history-pane', label: 'History') %>
+        <% component.with_tab(id: 'cocina-model-tab', pane_id: 'cocina-model-pane', label: 'Cocina JSON') %>
         <% component.with_tab(id: 'events-tab', pane_id: 'events-pane', label: 'Events') %>
         <% component.with_tab(id: 'technical-metadata-tab', pane_id: 'technical-metadata-pane', label: 'Technical metadata') if @solr_doc.dro? %>
-        <% component.with_tab(id: 'cocina-model-tab', pane_id: 'cocina-model-pane', label: 'Cocina JSON') %>
         <% component.with_tab(id: 'solr-doc-tab', pane_id: 'solr-doc-pane', label: 'SOLR doc') %>
+        <% component.with_tab(id: 'workflows-tab', pane_id: 'workflows-pane', label: 'Workflows') %>
+        <% component.with_tab(id: 'versions-tab', pane_id: 'versions-pane', label: 'Versions') %>
 
         <%= component.with_pane(id: 'overview-pane', tab_id: 'overview-tab', active: true) do %>
           <%= turbo_frame_tag(@solr_doc.druid, 'overview', src: overview_object_path(druid: @druid_token), refresh: 'morph', target: '_top') do %>
@@ -108,14 +109,12 @@
           <% end %>
         <% end %>
 
-        <%= component.with_pane(id: 'workflows-pane', tab_id: 'workflows-tab') do %>
-          <%= turbo_frame_tag(@solr_doc.druid, 'workflows', src: workflows_object_path(druid: @druid_token), refresh: 'morph', target: '_top') do %>
-            <%= render SdrViewComponents::Elements::SpinnerComponent.new %>
-          <% end %>
+        <%= component.with_pane(id: 'history-pane', tab_id: 'history-tab') do %>
+          <p>Not implemented yet</p>
         <% end %>
 
-        <%= component.with_pane(id: 'versions-pane', tab_id: 'versions-tab') do %>
-          <%= turbo_frame_tag(@solr_doc.druid, 'versions', src: versions_object_path(druid: @druid_token), refresh: 'morph', target: '_top') do %>
+        <%= component.with_pane(id: 'cocina-model-pane', tab_id: 'cocina-model-tab') do %>
+          <%= turbo_frame_tag(@solr_doc.druid, 'cocina_json', src: json_object_path(druid: @druid_token), refresh: 'morph', target: '_top') do %>
             <%= render SdrViewComponents::Elements::SpinnerComponent.new %>
           <% end %>
         <% end %>
@@ -128,14 +127,20 @@
           <p>Not implemented yet</p>
         <% end %>
 
-        <%= component.with_pane(id: 'cocina-model-pane', tab_id: 'cocina-model-tab') do %>
-          <%= turbo_frame_tag(@solr_doc.druid, 'cocina_json', src: json_object_path(druid: @druid_token), refresh: 'morph', target: '_top') do %>
+        <%= component.with_pane(id: 'solr-doc-pane', tab_id: 'solr-doc-tab') do %>
+          <%= turbo_frame_tag(@solr_doc.druid, 'solr_doc', src: solr_doc_object_path(druid: @druid_token), refresh: 'morph', target: '_top') do %>
             <%= render SdrViewComponents::Elements::SpinnerComponent.new %>
           <% end %>
         <% end %>
 
-        <%= component.with_pane(id: 'solr-doc-pane', tab_id: 'solr-doc-tab') do %>
-          <%= turbo_frame_tag(@solr_doc.druid, 'solr_doc', src: solr_doc_object_path(druid: @druid_token), refresh: 'morph', target: '_top') do %>
+        <%= component.with_pane(id: 'workflows-pane', tab_id: 'workflows-tab') do %>
+          <%= turbo_frame_tag(@solr_doc.druid, 'workflows', src: workflows_object_path(druid: @druid_token), refresh: 'morph', target: '_top') do %>
+            <%= render SdrViewComponents::Elements::SpinnerComponent.new %>
+          <% end %>
+        <% end %>
+
+        <%= component.with_pane(id: 'versions-pane', tab_id: 'versions-tab') do %>
+          <%= turbo_frame_tag(@solr_doc.druid, 'versions', src: versions_object_path(druid: @druid_token), refresh: 'morph', target: '_top') do %>
             <%= render SdrViewComponents::Elements::SpinnerComponent.new %>
           <% end %>
         <% end %>

--- a/app/views/objects/show.html.erb
+++ b/app/views/objects/show.html.erb
@@ -77,7 +77,7 @@
 
       <%= render SdrViewComponents::Elements::Tabs::TabListComponent.new(classes: 'mb-xl-3 my-4 my-xl-0', content_classes: 'mt-4', variant: :underline, collapse_below: :xl) do |component| %>
         <% component.with_tab(id: 'overview-tab', pane_id: 'overview-pane', label: 'Overview', active: true) %>
-        <% component.with_tab(id: 'purl-preview-tab', pane_id: 'purl-preview-pane', label: 'Description Preview') if @solr_doc.dro_or_collection? %>
+        <% component.with_tab(id: 'purl-preview-tab', pane_id: 'purl-preview-pane', label: 'Description preview') if @solr_doc.dro_or_collection? %>
         <% component.with_tab(id: 'files-tab', pane_id: 'files-pane', label: 'Files') if @solr_doc.dro? %>
         <% component.with_tab(id: 'history-tab', pane_id: 'history-pane', label: 'History') %>
         <% component.with_tab(id: 'cocina-model-tab', pane_id: 'cocina-model-pane', label: 'Cocina JSON') %>

--- a/spec/system/show_admin_policy_spec.rb
+++ b/spec/system/show_admin_policy_spec.rb
@@ -73,12 +73,13 @@ RSpec.describe 'Show admin policy' do
 
     # Tabs
     expect(page).to have_css('.nav-link.active', text: 'Overview')
+    expect(page).to have_css('.nav-link', text: 'History')
     expect(page).to have_css('.nav-link', text: 'Workflows')
     expect(page).to have_css('.nav-link', text: 'Versions')
     expect(page).to have_css('.nav-link', text: 'Events')
     expect(page).to have_css('.nav-link', text: 'Cocina JSON')
     expect(page).to have_css('.nav-link', text: 'SOLR doc')
-    expect(page).to have_no_css('.nav-link', text: 'Description Preview')
+    expect(page).to have_no_css('.nav-link', text: 'Description preview')
 
     # Overview table
     expect(page).to have_css('table[id="overview-table"] caption', text: 'Overview')

--- a/spec/system/show_collection_spec.rb
+++ b/spec/system/show_collection_spec.rb
@@ -85,7 +85,7 @@ RSpec.describe 'Show collection' do
     expect(page).to have_css('.nav-link', text: 'Events')
     expect(page).to have_css('.nav-link', text: 'Cocina JSON')
     expect(page).to have_css('.nav-link', text: 'SOLR doc')
-    expect(page).to have_css('.nav-link', text: 'Description Preview')
+    expect(page).to have_css('.nav-link', text: 'Description preview')
 
     # PURL link in side nav
     expect(page).to have_link('View PURL page', href: "https://purl.stanford.edu/#{DruidSupport.bare_druid_from(druid)}")
@@ -126,7 +126,7 @@ RSpec.describe 'Show collection' do
     expect(page).to have_css('andypf-json-viewer', text: original_title)
 
     # PURL preview tab
-    click_button 'Description Preview'
+    click_button 'Description preview'
     expect(page).to have_css('p', text: 'preview')
     expect(page).to have_link('View PURL page',
                               href: "https://purl.stanford.edu/#{DruidSupport.bare_druid_from(druid)}", count: 2)

--- a/spec/system/show_item_spec.rb
+++ b/spec/system/show_item_spec.rb
@@ -222,13 +222,14 @@ RSpec.describe 'Show item' do
 
     # Tabs
     expect(page).to have_css('.nav-link.active', text: 'Overview')
+    expect(page).to have_css('.nav-link', text: 'History')
     expect(page).to have_css('.nav-link', text: 'Workflows')
     expect(page).to have_css('.nav-link', text: 'Versions')
     expect(page).to have_css('.nav-link', text: 'Events')
     expect(page).to have_css('.nav-link', text: 'Files')
     expect(page).to have_css('.nav-link', text: 'Technical metadata')
     expect(page).to have_css('.nav-link', text: 'Cocina JSON')
-    expect(page).to have_css('.nav-link', text: 'Description Preview')
+    expect(page).to have_css('.nav-link', text: 'Description preview')
 
     # Overview table
     expect(page).to have_table_caption('overview-table', 'Overview')
@@ -378,7 +379,7 @@ RSpec.describe 'Show item' do
     expect(page).to have_css('li', text: 'rr624wq8610_00_0001.jp2')
 
     # PURL preview tab
-    click_button 'Description Preview'
+    click_button 'Description preview'
     expect(page).to have_css('p', text: 'preview')
     expect(page).to have_link('View PURL page',
                               href: "https://purl.stanford.edu/#{DruidSupport.bare_druid_from(druid)}", count: 2)


### PR DESCRIPTION
Fixes #254 - show page tab ordering

1. The tabs already appear to use Stanford Archway Dark, see https://github.com/sul-dlss/argo-b3/blob/main/app/assets/stylesheets/application.bootstrap.scss#L62-L65
2. The ordering and naming of tabs was made to match the Figma design as linked in the ticket.
3. Note that there is a new `History` tab shown in the Figma design.  This was added as not implemented, but the design appears to show it may be a combined Workflows/Versions tab view (which are not in the Figma design and were moved to the end of the tab list as described in the ticket).   Presumably the re-implementation of these tabs (and potential removal of unneeded ones) if left to other tickets.
4. Though not required, I moved the tab divs within the page to match the ordering of tabs for consistency.

<img width="1108" height="461" alt="Image" src="https://github.com/user-attachments/assets/87d945b1-e4dd-49c0-9f75-00423502c9d8" />