### PR TITLE
Show recently visited items on the dashboard

### DIFF
--- a/app/components/dashboard/pinned_apos_table_component.rb
+++ b/app/components/dashboard/pinned_apos_table_component.rb
@@ -17,13 +17,13 @@ module Dashboard
     end
 
     def title_link(apo_doc)
-      helpers.link_to(apo_doc.title, object_path(druid: apo_doc.druid))
+      helpers.link_to_object(apo_doc.title, apo_doc.druid)
     end
 
     def agreement_link(apo_doc)
       return if apo_doc.agreement_druid.blank?
 
-      helpers.link_to(apo_doc.agreement_title, object_path(druid: apo_doc.agreement_druid))
+      helpers.link_to_object(apo_doc.agreement_title, apo_doc.agreement_druid)
     end
 
     def classes

--- a/app/components/dashboard/pinned_collections_table_component.rb
+++ b/app/components/dashboard/pinned_collections_table_component.rb
@@ -17,11 +17,11 @@ module Dashboard
     end
 
     def title_link(item_doc)
-      helpers.link_to(item_doc.title, object_path(druid: item_doc.druid))
+      helpers.link_to_object(item_doc.title, item_doc.druid)
     end
 
     def apo_link(item_doc)
-      helpers.link_to(item_doc.apo_title, object_path(druid: item_doc.apo_druid))
+      helpers.link_to_object(item_doc.apo_title, item_doc.apo_druid)
     end
 
     def classes

--- a/app/components/dashboard/pinned_items_table_component.rb
+++ b/app/components/dashboard/pinned_items_table_component.rb
@@ -17,16 +17,16 @@ module Dashboard
     end
 
     def title_link(item_doc)
-      helpers.link_to(item_doc.title, object_path(druid: item_doc.druid))
+      helpers.link_to_object(item_doc.title, item_doc.druid)
     end
 
     def apo_link(item_doc)
-      helpers.link_to(item_doc.apo_title, object_path(druid: item_doc.apo_druid))
+      helpers.link_to_object(item_doc.apo_title, item_doc.apo_druid)
     end
 
     def collection_link_values(item_doc)
       Array(item_doc.collection_druids).map.with_index do |collection_druid, index|
-        helpers.link_to(item_doc.collection_titles[index], object_path(druid: collection_druid))
+        helpers.link_to_object(item_doc.collection_titles[index], collection_druid)
       end
     end
 

--- a/app/components/dashboard/pinned_virtual_objects_table_component.rb
+++ b/app/components/dashboard/pinned_virtual_objects_table_component.rb
@@ -17,16 +17,16 @@ module Dashboard
     end
 
     def title_link(virtual_object_doc)
-      helpers.link_to(virtual_object_doc.title, object_path(druid: virtual_object_doc.druid))
+      helpers.link_to_object(virtual_object_doc.title, virtual_object_doc.druid)
     end
 
     def apo_link(virtual_object_doc)
-      helpers.link_to(virtual_object_doc.apo_title, object_path(druid: virtual_object_doc.apo_druid))
+      helpers.link_to_object(virtual_object_doc.apo_title, virtual_object_doc.apo_druid)
     end
 
     def collection_link_values(virtual_object_doc)
       Array(virtual_object_doc.collection_druids).map.with_index do |collection_druid, index|
-        helpers.link_to(virtual_object_doc.collection_titles[index], object_path(druid: collection_druid))
+        helpers.link_to_object(virtual_object_doc.collection_titles[index], collection_druid)
       end
     end
 

--- a/app/components/dashboard/recent_objects_table_component.html.erb
+++ b/app/components/dashboard/recent_objects_table_component.html.erb
@@ -1,11 +1,11 @@
 <%= render SdrViewComponents::Tables::TableComponent.new(
-      empty_message: 'No objects have been viewed',
+      empty_message: 'No objects have been viewed.',
       classes:,
       label:,
       responsive: true
     ) do |component| %>
   <% component.with_caption do %>
-    <%= render SdrViewComponents::Elements::HeadingComponent.new(level: :h3, text: label) %>
+    <%= label %>
   <% end %>
   <% component.with_header(label: 'Title') %>
   <% component.with_header(label: 'Druid') %>

--- a/app/components/dashboard/recent_objects_table_component.html.erb
+++ b/app/components/dashboard/recent_objects_table_component.html.erb
@@ -1,6 +1,5 @@
 <%= render SdrViewComponents::Tables::TableComponent.new(
       empty_message: 'No objects have been viewed.',
-      classes:,
       label:,
       responsive: true
     ) do |component| %>

--- a/app/components/dashboard/recent_objects_table_component.html.erb
+++ b/app/components/dashboard/recent_objects_table_component.html.erb
@@ -1,0 +1,30 @@
+<%= render SdrViewComponents::Tables::TableComponent.new(
+      empty_message: 'No objects have been viewed',
+      classes:,
+      label:,
+      responsive: true
+    ) do |component| %>
+  <% component.with_caption do %>
+    <%= render SdrViewComponents::Elements::HeadingComponent.new(level: :h3, text: label) %>
+  <% end %>
+  <% component.with_header(label: 'Title') %>
+  <% component.with_header(label: 'Druid') %>
+  <% component.with_header(label: 'Object type') %>
+  <% component.with_header(label: 'Tags') %>
+  <% recent_object_docs.each do |object_doc| %>
+    <% component.with_row do |row_component| %>
+      <% row_component.with_cell do %>
+        <%= title_link(object_doc) %>
+      <% end %>
+      <% row_component.with_cell do %>
+        <%= object_doc.bare_druid %>
+      <% end %>
+      <% row_component.with_cell do %>
+        <%= object_type_label(object_doc) %>
+      <% end %>
+      <% row_component.with_cell do %>
+        <%= render SdrViewComponents::Tables::ListCellComponent.new(item_values: Array(object_doc.other_tags)) %>
+      <% end %>
+    <% end %>
+  <% end %>
+<% end %>

--- a/app/components/dashboard/recent_objects_table_component.rb
+++ b/app/components/dashboard/recent_objects_table_component.rb
@@ -1,0 +1,30 @@
+# frozen_string_literal: true
+
+module Dashboard
+  # Render the object show pages most recently visited by the user.
+  class RecentObjectsTableComponent < ApplicationComponent
+    def initialize(recent_object_docs:, classes: [])
+      @recent_object_docs = recent_object_docs
+      @classes = classes
+      super()
+    end
+
+    attr_reader :recent_object_docs
+
+    def label
+      'Recent objects'
+    end
+
+    def title_link(object_doc)
+      helpers.link_to_object(object_doc.title, object_doc.druid)
+    end
+
+    def object_type_label(object_doc)
+      SolrDocPresenter::OBJECT_TYPES.fetch(object_doc.object_type).fetch(:label)
+    end
+
+    def classes
+      merge_classes(@classes)
+    end
+  end
+end

--- a/app/components/dashboard/recent_objects_table_component.rb
+++ b/app/components/dashboard/recent_objects_table_component.rb
@@ -3,9 +3,8 @@
 module Dashboard
   # Render the object show pages most recently visited by the user.
   class RecentObjectsTableComponent < ApplicationComponent
-    def initialize(recent_object_docs:, classes: [])
+    def initialize(recent_object_docs:)
       @recent_object_docs = recent_object_docs
-      @classes = classes
       super()
     end
 
@@ -21,10 +20,6 @@ module Dashboard
 
     def object_type_label(object_doc)
       SolrDocPresenter::OBJECT_TYPES.fetch(object_doc.object_type).fetch(:label)
-    end
-
-    def classes
-      merge_classes(@classes)
     end
   end
 end

--- a/app/components/search/item_result_component.html.erb
+++ b/app/components/search/item_result_component.html.erb
@@ -5,8 +5,8 @@
         <% component.with_caption do %>
           <%= render Search::ResultHeadingComponent.new(index:) do |component| %>
             <%= component.with_link do %>
-              <%# Pre-fetch here breaks tests because can be triggered unintentionally. %>
-              <%= helpers.link_to(title, object_path(druid:), data: { turbo_frame: '_top', turbo_prefetch: !Rails.env.test? }) %>
+              <%# Prefetching would record hovered objects as recently viewed. %>
+              <%= helpers.link_to_object(title, druid, data: { turbo_frame: '_top' }) %>
             <% end %>
           <% end %>
         <% end %>

--- a/app/components/search/item_result_component.rb
+++ b/app/components/search/item_result_component.rb
@@ -24,9 +24,7 @@ module Search
     end
 
     def admin_policy_values
-      # Pre-fetch here breaks tests because can be triggered unintentionally.
-      [helpers.link_to(result.apo_title, object_path(druid: result.apo_druid),
-                       data: { turbo_frame: '_top', turbo_prefetch: !Rails.env.test? })]
+      [helpers.link_to_object(result.apo_title, result.apo_druid, data: { turbo_frame: '_top' })]
     end
 
     def collections_values
@@ -65,8 +63,7 @@ module Search
 
     def collection_links
       result.collection_druids.map.with_index do |collection_druid, index|
-        helpers.link_to(result.collection_titles[index], object_path(druid: collection_druid),
-                        data: { turbo_frame: '_top', turbo_prefetch: false })
+        helpers.link_to_object(result.collection_titles[index], collection_druid, data: { turbo_frame: '_top' })
       end
     end
 

--- a/app/controllers/dashboard_controller.rb
+++ b/app/controllers/dashboard_controller.rb
@@ -18,8 +18,16 @@ class DashboardController < ApplicationController
     Search::Fields::CONSTITUENTS_COUNT
   ].freeze
 
+  RECENT_OBJECT_FIELDS = [
+    Search::Fields::ID,
+    Search::Fields::TITLE,
+    Search::Fields::OBJECT_TYPES,
+    Search::Fields::OTHER_TAGS
+  ].freeze
+
   def index
     @go_to_druid_form = GoToDruidForm.new
+    set_recent_object_docs
     set_pinned_object_docs
     set_pinned_searches
   end
@@ -30,6 +38,7 @@ class DashboardController < ApplicationController
     if @go_to_druid_form.valid?
       redirect_to object_path(@go_to_druid_form.druid)
     else
+      set_recent_object_docs
       set_pinned_object_docs
       set_pinned_searches
       render :index, status: :unprocessable_content
@@ -37,6 +46,20 @@ class DashboardController < ApplicationController
   end
 
   private
+
+  def set_recent_object_docs
+    recent_object_druids = Array(session[:recent_object_druids])
+    @recent_object_docs = if recent_object_druids.present?
+                            recent_object_docs = Searchers::ItemByDruid.call(
+                              druids: recent_object_druids,
+                              fields: RECENT_OBJECT_FIELDS
+                            )
+                            docs_by_druid = recent_object_docs.index_by(&:druid)
+                            recent_object_druids.filter_map { |druid| docs_by_druid[druid] }
+                          else
+                            []
+                          end
+  end
 
   def set_pinned_searches
     @pinned_searches = PinnedSearch.where(user: current_user)

--- a/app/controllers/objects_controller.rb
+++ b/app/controllers/objects_controller.rb
@@ -2,6 +2,8 @@
 
 # Controller for objects (DRO, collection, admin policy)
 class ObjectsController < ApplicationController
+  RECENT_OBJECTS_LIMIT = 5
+
   skip_verify_authorized only: %i[show_json show_workflows show_overview show_header show_versions
                                   show_purl_preview show_solr_doc show_files]
 
@@ -39,6 +41,8 @@ class ObjectsController < ApplicationController
                                                          content:)
     release_tags = @solr_doc.dro_or_collection? ? Sdr::Repository.release_tags(druid:) : []
     @object_released_presenter = ObjectReleasedPresenter.new(document: @solr_doc, version_service:, release_tags:)
+
+    track_recent_object(druid) unless turbo_prefetch?
   end
 
   def show_header
@@ -103,6 +107,15 @@ class ObjectsController < ApplicationController
   end
 
   private
+
+  def track_recent_object(druid)
+    other_recent_druids = Array(session[:recent_object_druids]).excluding(druid)
+    session[:recent_object_druids] = [druid, *other_recent_druids].first(RECENT_OBJECTS_LIMIT)
+  end
+
+  def turbo_prefetch?
+    request.headers['X-Sec-Purpose'] == 'prefetch'
+  end
 
   def verified_druid
     @verified_druid ||= verify_token(params[:druid])

--- a/app/helpers/link_helper.rb
+++ b/app/helpers/link_helper.rb
@@ -2,6 +2,10 @@
 
 # Helper for creating links
 module LinkHelper
+  def link_to_object(label, druid, *, data: {}, **)
+    link_to(label, object_path(druid:), data: data.merge(turbo_prefetch: false), **)
+  end
+
   def link_to_new_tab(*, data: {}, **, &)
     link_to(*, target: '_blank', rel: 'noopener', data:, **, &)
   end

--- a/app/views/dashboard/index.html.erb
+++ b/app/views/dashboard/index.html.erb
@@ -59,17 +59,7 @@
 
       <%= render SdrViewComponents::Elements::HeadingComponent.new(level: :h2, text: 'My recent activity', classes: 'mt-3') %>
 
-      <%= render SdrViewComponents::Tables::TableComponent.new(classes: 'mb-5', responsive: true) do |component| %>
-        <% component.with_caption do %>
-          <%= render SdrViewComponents::Elements::HeadingComponent.new(level: :h3, text: 'Recent objects') %>
-        <% end %>
-        <% component.with_header(label: 'Title') %>
-        <% component.with_header(label: 'Druid') %>
-        <% component.with_header(label: 'Object type') %>
-        <% component.with_header(label: 'Tags') %>
-        <% component.with_row(values: ['Wiedoeft, Rudy Liver and bacon: fox trot: Emerson Records, New York...', 'bb234ab1234', 'Item', 'Project : Riegler-Deutsch Index']) %>
-        <% component.with_row(values: ['1947 Partition', 'bb234ab123', 'APO', nil]) %>
-      <% end %>
+      <%= render Dashboard::RecentObjectsTableComponent.new(recent_object_docs: @recent_object_docs, classes: 'mb-5') %>
 
       <div class="mb-5">
         <%= render Dashboard::PinnedSearchesTableComponent.new(pinned_searches: @pinned_searches) %>

--- a/app/views/dashboard/index.html.erb
+++ b/app/views/dashboard/index.html.erb
@@ -59,7 +59,9 @@
 
       <%= render SdrViewComponents::Elements::HeadingComponent.new(level: :h2, text: 'My recent activity', classes: 'mt-3') %>
 
-      <%= render Dashboard::RecentObjectsTableComponent.new(recent_object_docs: @recent_object_docs, classes: 'mb-5') %>
+      <div class="mb-5">
+        <%= render Dashboard::RecentObjectsTableComponent.new(recent_object_docs: @recent_object_docs) %>
+      </div>
 
       <div class="mb-5">
         <%= render Dashboard::PinnedSearchesTableComponent.new(pinned_searches: @pinned_searches) %>

--- a/app/views/objects/show_admin_policy_overview.html.erb
+++ b/app/views/objects/show_admin_policy_overview.html.erb
@@ -4,7 +4,7 @@
       <% component.with_row(label: 'Object type', value: 'Admin policy') %>
       <% component.with_row(label: 'Admin policy') do |row_component| %>
         <% row_component.with_cell do %>
-          <%= link_to @solr_doc.apo_title, object_path(druid: @solr_doc.apo_druid) %>
+          <%= link_to_object @solr_doc.apo_title, @solr_doc.apo_druid %>
           <% search_form = SearchForm.new(admin_policy_titles: [@solr_doc.apo_title]) %>
           (<%= link_to('All objects with this APO', search_path(search_form.attributes)) %>)
         <% end %>

--- a/app/views/objects/show_collection_overview.html.erb
+++ b/app/views/objects/show_collection_overview.html.erb
@@ -4,7 +4,7 @@
     <% component.with_row(label: 'Object type', value: 'Collection') %>
     <% component.with_row(label: 'Admin policy') do |row_component| %>
       <% row_component.with_cell do %>
-        <%= link_to @solr_doc.apo_title, object_path(druid: @solr_doc.apo_druid) %>
+        <%= link_to_object @solr_doc.apo_title, @solr_doc.apo_druid %>
         <% search_form = SearchForm.new(admin_policy_titles: [@solr_doc.apo_title]) %>
         (<%= link_to('All objects with this APO', search_path(search_form.attributes)) %>)
       <% end %>

--- a/app/views/objects/show_dro_overview.html.erb
+++ b/app/views/objects/show_dro_overview.html.erb
@@ -15,7 +15,7 @@
     <% component.with_caption do %><%= render SdrViewComponents::Elements::HeadingComponent.new(level: :h2, classes: 'mb-3', text: 'APO, Collection, Rights') %><% end %>
     <% component.with_row(label: 'Admin policy') do |row_component| %>
       <% row_component.with_cell do %>
-        <%= link_to @solr_doc.apo_title, object_path(druid: @solr_doc.apo_druid) %>
+        <%= link_to_object @solr_doc.apo_title, @solr_doc.apo_druid %>
         <% search_form = SearchForm.new(admin_policy_titles: [@solr_doc.apo_title]) %>
         (<%= link_to('All objects with this APO', search_path(search_form.attributes)) %>)
       <% end %>
@@ -24,7 +24,7 @@
       <% row_component.with_cell do %>
         <% Array(@solr_doc.collection_druids).each_with_index do |collection_druid, index| %>
           <% collection_title = Array(@solr_doc.collection_titles)[index] %>
-          <%= link_to collection_title, object_path(druid: collection_druid) %>
+          <%= link_to_object collection_title, collection_druid %>
           <% search_form = SearchForm.new(collection_titles: [collection_title]) %>
           (<%= link_to('All objects with this collection', search_path(search_form.attributes)) %>)
         <% end %>

--- a/spec/components/dashboard/recent_objects_table_component_spec.rb
+++ b/spec/components/dashboard/recent_objects_table_component_spec.rb
@@ -45,7 +45,7 @@ RSpec.describe Dashboard::RecentObjectsTableComponent, type: :component do
     it 'renders the empty message' do
       render_inline(component)
 
-      expect(page).to have_text('No objects have been viewed')
+      expect(page).to have_text('No objects have been viewed.')
     end
   end
 end

--- a/spec/components/dashboard/recent_objects_table_component_spec.rb
+++ b/spec/components/dashboard/recent_objects_table_component_spec.rb
@@ -1,0 +1,51 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe Dashboard::RecentObjectsTableComponent, type: :component do
+  include Rails.application.routes.url_helpers
+
+  let(:component) { described_class.new(recent_object_docs:) }
+  let(:druid) { 'druid:bc123df4567' }
+  let(:object_doc) do
+    SearchResults::Item.new(solr_doc: {
+                              Search::Fields::ID => druid,
+                              Search::Fields::TITLE => 'Liver and bacon: fox trot',
+                              Search::Fields::OBJECT_TYPES => ['item'],
+                              Search::Fields::OTHER_TAGS => ['Project : Riegler-Deutsch Index', 'Remediated']
+                            })
+  end
+
+  context 'when objects have been viewed' do
+    let(:recent_object_docs) { [object_doc] }
+
+    it 'renders the recent objects' do
+      render_inline(component)
+
+      table = page.find('table[aria-label="Recent objects"]')
+      expect(table).to have_css('caption', text: 'Recent objects')
+      expect(table).to have_css('th', text: 'Title')
+      expect(table).to have_css('th', text: 'Druid')
+      expect(table).to have_css('th', text: 'Object type')
+      expect(table).to have_css('th', text: 'Tags')
+
+      cells = table.find('tbody tr').all('td')
+      expect(cells[0]).to have_link('Liver and bacon: fox trot', href: object_path(druid:))
+      expect(cells[0].find('a')['data-turbo-prefetch']).to eq('false')
+      expect(cells[1]).to have_text('bc123df4567')
+      expect(cells[2]).to have_text('Item')
+      expect(cells[3]).to have_text('Project : Riegler-Deutsch Index')
+      expect(cells[3]).to have_text('Remediated')
+    end
+  end
+
+  context 'when no objects have been viewed' do
+    let(:recent_object_docs) { [] }
+
+    it 'renders the empty message' do
+      render_inline(component)
+
+      expect(page).to have_text('No objects have been viewed')
+    end
+  end
+end

--- a/spec/helpers/link_helper_spec.rb
+++ b/spec/helpers/link_helper_spec.rb
@@ -3,6 +3,16 @@
 require 'rails_helper'
 
 RSpec.describe LinkHelper do
+  describe '#link_to_object' do
+    it 'disables Turbo prefetching' do
+      link = helper.link_to_object('An object', 'druid:bc123df4567', data: { turbo_frame: '_top' })
+
+      expect(link).to include('href="/objects/druid:bc123df4567"')
+      expect(link).to include('data-turbo-frame="_top"')
+      expect(link).to include('data-turbo-prefetch="false"')
+    end
+  end
+
   describe '#searchworks_url' do
     let(:druid) { 'druid:bc123df4567' }
 

--- a/spec/requests/dashboard_spec.rb
+++ b/spec/requests/dashboard_spec.rb
@@ -20,7 +20,6 @@ RSpec.describe 'Dashboard' do
     let(:recent_object_druids) do
       %w[
         druid:bc123df4567
-        druid:cd234fg5678
         druid:df345hj6789
       ]
     end
@@ -34,8 +33,7 @@ RSpec.describe 'Dashboard' do
           Search::Fields::TITLE => "Title #{DruidSupport.bare_druid_from(object_druid)}",
           Search::Fields::OBJECT_TYPES => ['item'],
           Search::Fields::CONTENT_TYPES => ['book'],
-          Search::Fields::OTHER_TAGS => [],
-          Search::Fields::WORKFLOW_ERRORS => []
+          Search::Fields::OTHER_TAGS => []
         }
       end
     end
@@ -47,26 +45,31 @@ RSpec.describe 'Dashboard' do
       allow(Sdr::Repository).to receive(:release_tags).and_return([])
       allow(Sdr::VersionService).to receive(:new).and_return(version_service)
       allow(Searchers::ItemByDruid).to receive(:call).and_return(
-        [recent_object_druids.first, recent_object_druids.last].map do |recent_object_druid|
+        recent_object_druids.map do |recent_object_druid|
           SearchResults::Item.new(solr_doc: solr_doc_for.call(recent_object_druid))
         end
       )
     end
 
-    it 'displays available objects in most-recently-viewed order' do
-      recent_object_druids.each { |recent_object_druid| get object_path(recent_object_druid) }
-
+    it 'displays objects only after their show pages have been visited' do
+      # visit the dashboard and ensure we don't have our fixture objects in the recent objects table
       get root_path
+      recent_objects_table = response.parsed_body.at_css('table[aria-label="Recent objects"]')
+      recent_object_druids.each do |recent_object_druid|
+        recent_object_title = "Title #{DruidSupport.bare_druid_from(recent_object_druid)}"
+        expect(recent_objects_table.text).not_to include(recent_object_title)
 
-      newest_title = "Title #{DruidSupport.bare_druid_from(recent_object_druids.last)}"
-      oldest_title = "Title #{DruidSupport.bare_druid_from(recent_object_druids.first)}"
-      missing_title = "Title #{DruidSupport.bare_druid_from(recent_object_druids.second)}"
-      expect(response.body.index(newest_title)).to be < response.body.index(oldest_title)
-      expect(response.body).not_to include(missing_title)
-      expect(Searchers::ItemByDruid).to have_received(:call).with(
-        druids: recent_object_druids.reverse,
-        fields: DashboardController::RECENT_OBJECT_FIELDS
-      )
+        # now view the object
+        get object_path(recent_object_druid)
+      end
+
+      # Back to dashboard, check to see if objects we viewed are now in the recent objects table on the dashboard
+      get root_path
+      recent_objects_table = response.parsed_body.at_css('table[aria-label="Recent objects"]')
+      recent_object_druids.each do |recent_object_druid|
+        recent_object_title = "Title #{DruidSupport.bare_druid_from(recent_object_druid)}"
+        expect(recent_objects_table.text).to include(recent_object_title)
+      end
     end
   end
 

--- a/spec/requests/dashboard_spec.rb
+++ b/spec/requests/dashboard_spec.rb
@@ -16,6 +16,60 @@ RSpec.describe 'Dashboard' do
     expect(response).to have_http_status(:ok)
   end
 
+  context 'when objects have recently been viewed' do
+    let(:recent_object_druids) do
+      %w[
+        druid:bc123df4567
+        druid:cd234fg5678
+        druid:df345hj6789
+      ]
+    end
+    let(:version_service) do
+      instance_double(Sdr::VersionService, accessioning?: false, closed?: false, open?: true, version: 1)
+    end
+    let(:solr_doc_for) do
+      lambda do |object_druid|
+        {
+          Search::Fields::ID => object_druid,
+          Search::Fields::TITLE => "Title #{DruidSupport.bare_druid_from(object_druid)}",
+          Search::Fields::OBJECT_TYPES => ['item'],
+          Search::Fields::CONTENT_TYPES => ['book'],
+          Search::Fields::OTHER_TAGS => [],
+          Search::Fields::WORKFLOW_ERRORS => []
+        }
+      end
+    end
+
+    before do
+      allow(Sdr::Repository).to receive(:lock) { |druid:| "lock-#{druid}" }
+      allow(Sdr::Repository).to receive(:find_solr) { |druid:| solr_doc_for.call(druid) }
+      allow(Sdr::Repository).to receive(:find) { |druid:| build(:dro_with_metadata, id: druid) }
+      allow(Sdr::Repository).to receive(:release_tags).and_return([])
+      allow(Sdr::VersionService).to receive(:new).and_return(version_service)
+      allow(Searchers::ItemByDruid).to receive(:call).and_return(
+        [recent_object_druids.first, recent_object_druids.last].map do |recent_object_druid|
+          SearchResults::Item.new(solr_doc: solr_doc_for.call(recent_object_druid))
+        end
+      )
+    end
+
+    it 'displays available objects in most-recently-viewed order' do
+      recent_object_druids.each { |recent_object_druid| get object_path(recent_object_druid) }
+
+      get root_path
+
+      newest_title = "Title #{DruidSupport.bare_druid_from(recent_object_druids.last)}"
+      oldest_title = "Title #{DruidSupport.bare_druid_from(recent_object_druids.first)}"
+      missing_title = "Title #{DruidSupport.bare_druid_from(recent_object_druids.second)}"
+      expect(response.body.index(newest_title)).to be < response.body.index(oldest_title)
+      expect(response.body).not_to include(missing_title)
+      expect(Searchers::ItemByDruid).to have_received(:call).with(
+        druids: recent_object_druids.reverse,
+        fields: DashboardController::RECENT_OBJECT_FIELDS
+      )
+    end
+  end
+
   describe 'POST /go_to_druid' do
     before do
       allow(Sdr::Repository).to receive(:find_solr).with(druid:).and_return({})

--- a/spec/requests/show/show_spec.rb
+++ b/spec/requests/show/show_spec.rb
@@ -4,9 +4,6 @@ require 'rails_helper'
 
 RSpec.describe 'Show object' do
   let(:druid) { 'druid:bc123df4567' }
-  let(:version_service) do
-    instance_double(Sdr::VersionService, accessioning?: false, closed?: false, open?: true, version: 1)
-  end
 
   before do
     sign_in(create(:user))
@@ -23,68 +20,6 @@ RSpec.describe 'Show object' do
         get "/objects/#{druid}"
 
         expect(response).to have_http_status(:not_found)
-      end
-    end
-
-    context 'when the object is found' do
-      let(:druids) do
-        %w[
-          druid:bc123df4567
-          druid:cd234fg5678
-          druid:df345hj6789
-          druid:fg456jk7890
-          druid:gh567km8901
-          druid:hj678np9012
-        ]
-      end
-
-      before do
-        allow(Sdr::Repository).to receive(:lock) { |druid:| "lock-#{druid}" }
-        allow(Sdr::Repository).to receive(:find_solr) { |druid:| solr_doc(druid) }
-        allow(Sdr::Repository).to receive(:find) { |druid:| build(:dro_with_metadata, id: druid) }
-        allow(Sdr::Repository).to receive(:release_tags).and_return([])
-        allow(Sdr::VersionService).to receive(:new).and_return(version_service)
-        allow(Searchers::ItemByDruid).to receive(:call) do |druids:, **|
-          druids.map { |recent_druid| SearchResults::Item.new(solr_doc: solr_doc(recent_druid)) }
-        end
-      end
-
-      it 'keeps the five most recently shown unique objects and displays them in order' do
-        druids.each { |recent_druid| get object_path(recent_druid) }
-
-        expect(session[:recent_object_druids]).to eq(druids.last(5).reverse)
-
-        get object_path(druids[3])
-
-        expect(session[:recent_object_druids]).to eq([druids[3], druids[5], druids[4], druids[2], druids[1]])
-
-        get root_path
-
-        expect(response.body.index(title_for(druids[3]))).to be < response.body.index(title_for(druids[5]))
-        expect(Searchers::ItemByDruid).to have_received(:call).with(
-          druids: session[:recent_object_druids], fields: DashboardController::RECENT_OBJECT_FIELDS
-        )
-      end
-
-      it 'does not track Turbo prefetch requests' do
-        get object_path(druid), headers: { 'X-Sec-Purpose' => 'prefetch' }
-
-        expect(session[:recent_object_druids]).to be_nil
-      end
-
-      def solr_doc(recent_druid)
-        {
-          Search::Fields::ID => recent_druid,
-          Search::Fields::TITLE => title_for(recent_druid),
-          Search::Fields::OBJECT_TYPES => ['item'],
-          Search::Fields::CONTENT_TYPES => ['book'],
-          Search::Fields::OTHER_TAGS => ["Project : #{DruidSupport.bare_druid_from(recent_druid)}"],
-          Search::Fields::WORKFLOW_ERRORS => []
-        }
-      end
-
-      def title_for(recent_druid)
-        "Title #{DruidSupport.bare_druid_from(recent_druid)}"
       end
     end
   end

--- a/spec/requests/show/show_spec.rb
+++ b/spec/requests/show/show_spec.rb
@@ -4,6 +4,9 @@ require 'rails_helper'
 
 RSpec.describe 'Show object' do
   let(:druid) { 'druid:bc123df4567' }
+  let(:version_service) do
+    instance_double(Sdr::VersionService, accessioning?: false, closed?: false, open?: true, version: 1)
+  end
 
   before do
     sign_in(create(:user))
@@ -20,6 +23,68 @@ RSpec.describe 'Show object' do
         get "/objects/#{druid}"
 
         expect(response).to have_http_status(:not_found)
+      end
+    end
+
+    context 'when the object is found' do
+      let(:druids) do
+        %w[
+          druid:bc123df4567
+          druid:cd234fg5678
+          druid:df345hj6789
+          druid:fg456jk7890
+          druid:gh567km8901
+          druid:hj678np9012
+        ]
+      end
+
+      before do
+        allow(Sdr::Repository).to receive(:lock) { |druid:| "lock-#{druid}" }
+        allow(Sdr::Repository).to receive(:find_solr) { |druid:| solr_doc(druid) }
+        allow(Sdr::Repository).to receive(:find) { |druid:| build(:dro_with_metadata, id: druid) }
+        allow(Sdr::Repository).to receive(:release_tags).and_return([])
+        allow(Sdr::VersionService).to receive(:new).and_return(version_service)
+        allow(Searchers::ItemByDruid).to receive(:call) do |druids:, **|
+          druids.map { |recent_druid| SearchResults::Item.new(solr_doc: solr_doc(recent_druid)) }
+        end
+      end
+
+      it 'keeps the five most recently shown unique objects and displays them in order' do
+        druids.each { |recent_druid| get object_path(recent_druid) }
+
+        expect(session[:recent_object_druids]).to eq(druids.last(5).reverse)
+
+        get object_path(druids[3])
+
+        expect(session[:recent_object_druids]).to eq([druids[3], druids[5], druids[4], druids[2], druids[1]])
+
+        get root_path
+
+        expect(response.body.index(title_for(druids[3]))).to be < response.body.index(title_for(druids[5]))
+        expect(Searchers::ItemByDruid).to have_received(:call).with(
+          druids: session[:recent_object_druids], fields: DashboardController::RECENT_OBJECT_FIELDS
+        )
+      end
+
+      it 'does not track Turbo prefetch requests' do
+        get object_path(druid), headers: { 'X-Sec-Purpose' => 'prefetch' }
+
+        expect(session[:recent_object_druids]).to be_nil
+      end
+
+      def solr_doc(recent_druid)
+        {
+          Search::Fields::ID => recent_druid,
+          Search::Fields::TITLE => title_for(recent_druid),
+          Search::Fields::OBJECT_TYPES => ['item'],
+          Search::Fields::CONTENT_TYPES => ['book'],
+          Search::Fields::OTHER_TAGS => ["Project : #{DruidSupport.bare_druid_from(recent_druid)}"],
+          Search::Fields::WORKFLOW_ERRORS => []
+        }
+      end
+
+      def title_for(recent_druid)
+        "Title #{DruidSupport.bare_druid_from(recent_druid)}"
       end
     end
   end

--- a/spec/system/show_dashboard_spec.rb
+++ b/spec/system/show_dashboard_spec.rb
@@ -22,7 +22,7 @@ RSpec.describe 'Show dashboard', :rack_test do
       expect(page).to have_no_button('Manage permissions')
       expect(page).to have_no_button('Impersonate')
 
-      expect(page).to have_css('table caption', text: 'Recent objects')
+      expect(page).to have_css('table[aria-label="Recent objects"]')
       expect(page).to have_css('table[aria-label="Pinned searches"]')
       expect(page).to have_css('table[aria-label="Pinned items"]')
       expect(page).to have_css('table[aria-label="Pinned collections"]')


### PR DESCRIPTION
Fixes #273

<img width="1104" height="446" alt="Screenshot 2026-08-25 at 4 25 10 PM" src="https://github.com/user-attachments/assets/7f930d7a-3b8a-4212-8a69-ad51a959d9fc" />

Show five most recently visited items on the dashboard.

1. Recent druids stored in the session.
2. Table built from dashboard using stored druids.
3. No recent items show the appropriate message.
4. Adds a new helper method for linking to objects which explicitly disables turbo pre-fetch so we can be sure a pre-fetch call does not trigger recent history.  Use this new helper for object links throughout.

Most of the code changes are switching object links to using the new non-turbo prefetch helper.  There is also a guard against storing recent objects if it thinks it is a pre-fetch, but here is why Codex thinks both are prudent:

```
Turbo reuses the prefetched response when the link is clicked:
1. Hover sends a GET with X-Sec-Purpose: prefetch.
2. The controller guard correctly avoids recording it.
3. Clicking may use that cached response without another server request.
4. The genuine visit would therefore never be recorded.
Disabling prefetch on object links ensures clicks reach the controller. The controller guard remains defense-in-depth for any object link that is missed or added later. Keeping both preserves correct click tracking while preventing hover tracking.
```

Note: Codex assisted code, with some manual tweaks.