### PR TITLE
Pinned tags on dashboard and Tags box on show page

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -581,7 +581,7 @@ GEM
     ruby-next-core (1.2.1)
     ruby-progressbar (1.13.0)
     rubyzip (3.5.0)
-    sdr_view_components (0.11.0)
+    sdr_view_components (0.11.1)
       rails (~> 8.0)
       view_component
       zeitwerk

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -581,7 +581,7 @@ GEM
     ruby-next-core (1.2.1)
     ruby-progressbar (1.13.0)
     rubyzip (3.5.0)
-    sdr_view_components (0.10.0)
+    sdr_view_components (0.11.0)
       rails (~> 8.0)
       view_component
       zeitwerk

--- a/app/assets/stylesheets/application.bootstrap.scss
+++ b/app/assets/stylesheets/application.bootstrap.scss
@@ -81,7 +81,11 @@ $search-color: rgb(#{$search-color-rgb});
   }
 
   // Avoids the pin flashing a background when clicked.
+  // (Transparent background otherwise comes from sdr_view_components' .icon-button.btn rule.)
   &.btn {
     --bs-btn-disabled-bg: transparent !important;
+
+    // Removes vertical button padding so pin rows don't take up more height than plain text rows.
+    --bs-btn-padding-y: 0;
   }
 }

--- a/app/assets/stylesheets/application.bootstrap.scss
+++ b/app/assets/stylesheets/application.bootstrap.scss
@@ -80,12 +80,8 @@ $search-color: rgb(#{$search-color-rgb});
     color: black;
   }
 
-  // Avoids the pin flashing a background when clicked.
-  // (Transparent background otherwise comes from sdr_view_components' .icon-button.btn rule.)
   &.btn {
-    --bs-btn-disabled-bg: transparent !important;
-
-    // Removes vertical button padding so pin rows don't take up more height than plain text rows.
+    // Removes vertical button padding so pin rows don't take up more height than text.
     --bs-btn-padding-y: 0;
   }
 }

--- a/app/assets/stylesheets/show.scss
+++ b/app/assets/stylesheets/show.scss
@@ -20,6 +20,11 @@
     > .border {
       height: 180px;
       overflow-y: auto;
+      scrollbar-color: var(--stanford-70-black) transparent;
+
+      &::-webkit-scrollbar-thumb {
+        background-color: var(--stanford-70-black);
+      }
     }
   }
 
@@ -55,6 +60,16 @@
 
   .file-set-card {
     background-color: var(--stanford-fog-light);
+  }
+
+  .dotted-underline-links a {
+    color: var(--stanford-70-black);
+    text-decoration-line: underline;
+    text-decoration-style: dotted;
+
+    &:hover {
+      text-decoration-style: solid;
+    }
   }
 }
 
@@ -98,4 +113,10 @@
 
 .object-type-search {
   @include object-type-colors($search-color, $search-color-rgb);
+}
+
+.object-type-tag {
+  .pinned {
+    color: black;
+  }
 }

--- a/app/components/concerns/faceted_tag_link_concern.rb
+++ b/app/components/concerns/faceted_tag_link_concern.rb
@@ -1,0 +1,21 @@
+# frozen_string_literal: true
+
+# Provides a search path for a tag, routing tags with a recognized prefix (e.g., "Ticket : ...",
+# "Project : ...") to that facet's search path (with the prefix stripped) instead of the
+# generic tags search path, since those tags are indexed into their own facet field.
+module FacetedTagLinkConcern
+  extend ActiveSupport::Concern
+
+  FACETED_TAG_PREFIXES = {
+    'Ticket' => :tickets,
+    'Project' => :projects
+  }.freeze
+
+  def search_path_for(tag)
+    prefix, value = tag.split(' : ', 2)
+    form_field = FACETED_TAG_PREFIXES[prefix]
+    return search_path(tags: [tag]) unless form_field && value
+
+    search_path(form_field => [value])
+  end
+end

--- a/app/components/dashboard/pinned_tags_table_component.html.erb
+++ b/app/components/dashboard/pinned_tags_table_component.html.erb
@@ -1,0 +1,23 @@
+<%= render SdrViewComponents::Tables::TableComponent.new(
+      empty_message: 'No tags have been pinned.',
+      classes:,
+      label:,
+      responsive: true
+    ) do |component| %>
+  <% component.with_caption do %>
+    <%= label %>
+    <%= helpers.pin_icon(classes: 'pinned') %>
+  <% end %>
+  <% component.with_header(label: 'Tag') %>
+  <% component.with_header(label: 'Unpin') %>
+  <% pinned_tags.each do |pinned_tag| %>
+    <% component.with_row do |row_component| %>
+      <% row_component.with_cell do %>
+        <%= tag_link(pinned_tag) %>
+      <% end %>
+      <% row_component.with_cell do %>
+        <%= render Pin::PinnedTagComponent.new(tag: pinned_tag.tag, pinned: true) %>
+      <% end %>
+    <% end %>
+  <% end %>
+<% end %>

--- a/app/components/dashboard/pinned_tags_table_component.rb
+++ b/app/components/dashboard/pinned_tags_table_component.rb
@@ -3,6 +3,8 @@
 module Dashboard
   # Render the table of a user's pinned tags on the dashboard.
   class PinnedTagsTableComponent < ApplicationComponent
+    include FacetedTagLinkConcern
+
     # @param pinned_tags [Array] the pinned tags
     def initialize(pinned_tags:, classes: [])
       @pinned_tags = pinned_tags
@@ -17,7 +19,7 @@ module Dashboard
     end
 
     def tag_link(pinned_tag)
-      helpers.link_to(pinned_tag.tag, search_path(tags: [pinned_tag.tag]))
+      helpers.link_to(pinned_tag.tag, search_path_for(pinned_tag.tag))
     end
 
     def classes

--- a/app/components/dashboard/pinned_tags_table_component.rb
+++ b/app/components/dashboard/pinned_tags_table_component.rb
@@ -1,0 +1,27 @@
+# frozen_string_literal: true
+
+module Dashboard
+  # Render the table of a user's pinned tags on the dashboard.
+  class PinnedTagsTableComponent < ApplicationComponent
+    # @param pinned_tags [Array] the pinned tags
+    def initialize(pinned_tags:, classes: [])
+      @pinned_tags = pinned_tags
+      @classes = classes
+      super()
+    end
+
+    attr_reader :pinned_tags
+
+    def label
+      'Pinned tags'
+    end
+
+    def tag_link(pinned_tag)
+      helpers.link_to(pinned_tag.tag, search_path(tags: [pinned_tag.tag]))
+    end
+
+    def classes
+      merge_classes('object-type-tag', @classes)
+    end
+  end
+end

--- a/app/components/pin/pinned_tag_component.html.erb
+++ b/app/components/pin/pinned_tag_component.html.erb
@@ -1,0 +1,16 @@
+<% if pinned %>
+  <%= render SdrViewComponents::Elements::IconButtonFormComponent.new(link: pinned_tag_path(tag),
+                                                                      icon: :pin,
+                                                                      label: 'Unpin',
+                                                                      method: :delete,
+                                                                      classes: "pin pinned #{classes}",
+                                                                      icon_classes:) %>
+<% else %>
+  <%= render SdrViewComponents::Elements::IconButtonFormComponent.new(link: pinned_tags_path,
+                                                                      icon: :unpin,
+                                                                      label: 'Pin',
+                                                                      method: :post,
+                                                                      params: { tag: },
+                                                                      classes: "pin not-pinned #{classes}",
+                                                                      icon_classes:) %>
+<% end %>

--- a/app/components/pin/pinned_tag_component.rb
+++ b/app/components/pin/pinned_tag_component.rb
@@ -1,0 +1,25 @@
+# frozen_string_literal: true
+
+module Pin
+  # Renders the button for pinning or unpinning a tag.
+  class PinnedTagComponent < ApplicationComponent
+    # @param compact [Boolean] renders a smaller, tightly-padded button, for use in dense lists
+    #   like the object show page's Tags box
+    def initialize(tag:, pinned:, compact: false)
+      @tag = tag
+      @pinned = pinned
+      @compact = compact
+      super()
+    end
+
+    attr_reader :tag, :pinned, :compact
+
+    def classes
+      compact ? 'p-0' : ''
+    end
+
+    def icon_classes
+      compact ? '' : 'fs-4'
+    end
+  end
+end

--- a/app/components/show/released_to_component.html.erb
+++ b/app/components/show/released_to_component.html.erb
@@ -1,6 +1,6 @@
 <%= render Show::BoxComponent.new(heading:) do %>
   <% if release_tag_links.any? %>
-    <ul>
+    <ul class="dotted-underline-links">
       <% release_tag_links.each do |release_tag_link| %>
         <li><%= helpers.link_to_new_tab(release_tag_link[:label], release_tag_link[:url]) %></li>
       <% end %>

--- a/app/components/show/tag_component.html.erb
+++ b/app/components/show/tag_component.html.erb
@@ -1,0 +1,12 @@
+<%= render Show::BoxComponent.new(heading: 'Tags') do %>
+  <ul class="object-type-tag mb-0 dotted-underline-links">
+    <% tags.each do |tag| %>
+      <li>
+        <span class="d-inline-flex align-items-end gap-1">
+          <%= link_to tag, search_path_for(tag) %>
+          <%= render Pin::PinnedTagComponent.new(tag:, pinned: pinned?(tag), compact: true) %>
+        </span>
+      </li>
+    <% end %>
+  </ul>
+<% end %>

--- a/app/components/show/tag_component.rb
+++ b/app/components/show/tag_component.rb
@@ -1,0 +1,20 @@
+# frozen_string_literal: true
+
+module Show
+  # Component for rendering the tags box on the show page.
+  class TagComponent < ApplicationComponent
+    include FacetedTagLinkConcern
+
+    def initialize(tags:, pinned_tags:)
+      @tags = tags
+      @pinned_tags = pinned_tags
+      super()
+    end
+
+    attr_reader :tags, :pinned_tags
+
+    def pinned?(tag)
+      pinned_tags.include?(tag)
+    end
+  end
+end

--- a/app/controllers/dashboard_controller.rb
+++ b/app/controllers/dashboard_controller.rb
@@ -30,6 +30,7 @@ class DashboardController < ApplicationController
     set_recent_object_docs
     set_pinned_object_docs
     set_pinned_searches
+    set_pinned_tags
   end
 
   def go_to_druid
@@ -41,6 +42,7 @@ class DashboardController < ApplicationController
       set_recent_object_docs
       set_pinned_object_docs
       set_pinned_searches
+      set_pinned_tags
       render :index, status: :unprocessable_content
     end
   end
@@ -63,6 +65,10 @@ class DashboardController < ApplicationController
 
   def set_pinned_searches
     @pinned_searches = PinnedSearch.where(user: current_user)
+  end
+
+  def set_pinned_tags
+    @pinned_tags = PinnedTag.where(user: current_user)
   end
 
   def set_pinned_object_docs

--- a/app/controllers/objects_controller.rb
+++ b/app/controllers/objects_controller.rb
@@ -43,6 +43,7 @@ class ObjectsController < ApplicationController
     @object_released_presenter = ObjectReleasedPresenter.new(document: @solr_doc, version_service:, release_tags:)
 
     track_recent_object(druid) unless turbo_prefetch?
+    @pinned_tags = PinnedTag.where(user: current_user).pluck(:tag).to_set
   end
 
   def show_header

--- a/app/controllers/pinned_tags_controller.rb
+++ b/app/controllers/pinned_tags_controller.rb
@@ -1,0 +1,30 @@
+# frozen_string_literal: true
+
+# Controller for managing pinned tags
+class PinnedTagsController < ApplicationController
+  # Any caller of create or destroy will want to include:
+  # <% content_for :head do %>
+  #   <meta name="turbo-refresh-method" content="morph">
+  #   <meta name="turbo-refresh-scroll" content="preserve">
+  # <% end %>
+
+  # No reason to authorize since the user can only be the user.
+  skip_verify_authorized
+
+  def create
+    PinnedTag.find_or_create_by!(user: current_user, tag: params[:tag])
+
+    flash[:toast] = t('pinned.pin_added')
+
+    redirect_to request.referer || root_path, status: :see_other
+  end
+
+  def destroy
+    pinned_tag = PinnedTag.find_by!(tag: params.expect(:id), user: current_user)
+    pinned_tag.destroy!
+
+    flash[:toast] = t('pinned.pin_removed')
+
+    redirect_to request.referer || root_path, status: :see_other
+  end
+end

--- a/app/controllers/pinned_tags_controller.rb
+++ b/app/controllers/pinned_tags_controller.rb
@@ -8,7 +8,7 @@ class PinnedTagsController < ApplicationController
   #   <meta name="turbo-refresh-scroll" content="preserve">
   # <% end %>
 
-  # No reason to authorize since the user can only be the user.
+  # No reason to authorize since tags lookup is scoped to the current user
   skip_verify_authorized
 
   def create

--- a/app/views/dashboard/index.html.erb
+++ b/app/views/dashboard/index.html.erb
@@ -81,6 +81,10 @@
         <%= render Dashboard::PinnedAposTableComponent.new(pinned_apo_docs: @pinned_apo_docs) %>
       </div>
 
+      <div class="mb-5">
+        <%= render Dashboard::PinnedTagsTableComponent.new(pinned_tags: @pinned_tags) %>
+      </div>
+
       <%= render Dashboard::PinnedVirtualObjectsTableComponent.new(pinned_virtual_object_docs: @pinned_virtual_object_docs) %>
     <% end %>
   <% end %>

--- a/app/views/objects/show.html.erb
+++ b/app/views/objects/show.html.erb
@@ -66,18 +66,7 @@
           </div>
         <% end %>
         <div class="show-box flex-fill">
-          <%= render Show::BoxComponent.new(heading: 'Tags') do %>
-            <ul class="object-type-tag mb-0 dotted-underline-links">
-              <% (Array(@solr_doc.tickets) + Array(@solr_doc.other_tags)).each do |tag| %>
-                <li>
-                  <span class="d-inline-flex align-items-end gap-1">
-                    <%= link_to tag, search_path(tags: [tag]) %>
-                    <%= render Pin::PinnedTagComponent.new(tag:, pinned: @pinned_tags.include?(tag), compact: true) %>
-                  </span>
-                </li>
-              <% end %>
-            </ul>
-          <% end %>
+          <%= render Show::TagComponent.new(tags: Array(@solr_doc.other_tags), pinned_tags: @pinned_tags) %>
         </div>
       </div>
 

--- a/app/views/objects/show.html.erb
+++ b/app/views/objects/show.html.erb
@@ -67,10 +67,14 @@
         <% end %>
         <div class="show-box flex-fill">
           <%= render Show::BoxComponent.new(heading: 'Tags') do %>
-            <ul>
-              <!-- Placeholder -- these aren't the right list of tags. -->
+            <ul class="object-type-tag mb-0 dotted-underline-links">
               <% (Array(@solr_doc.tickets) + Array(@solr_doc.other_tags)).each do |tag| %>
-                <li><%= tag %></li>
+                <li>
+                  <span class="d-inline-flex align-items-end gap-1">
+                    <%= link_to tag, search_path(tags: [tag]) %>
+                    <%= render Pin::PinnedTagComponent.new(tag:, pinned: @pinned_tags.include?(tag), compact: true) %>
+                  </span>
+                </li>
               <% end %>
             </ul>
           <% end %>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -181,6 +181,8 @@ Rails.application.routes.draw do
 
   resources :pinned_searches, only: %i[create destroy]
 
+  resources :pinned_tags, only: %i[create destroy]
+
   namespace :admin do
     get 'groups'
   end

--- a/spec/components/dashboard/pinned_tags_table_component_spec.rb
+++ b/spec/components/dashboard/pinned_tags_table_component_spec.rb
@@ -8,7 +8,7 @@ RSpec.describe Dashboard::PinnedTagsTableComponent, type: :component do
   let(:component) { described_class.new(pinned_tags:) }
 
   context 'when there are pinned tags' do
-    let(:pinned_tags) { [build(:pinned_tag, tag: 'Project : Foo')] }
+    let(:pinned_tags) { [build(:pinned_tag, tag: 'Registered By : jdoe')] }
 
     it 'renders a row for each pinned tag' do
       render_inline(component)
@@ -21,7 +21,7 @@ RSpec.describe Dashboard::PinnedTagsTableComponent, type: :component do
 
       row = table.find('tbody tr')
       cells = row.all('td')
-      expect(cells[0]).to have_link('Project : Foo', href: search_path(tags: ['Project : Foo']))
+      expect(cells[0]).to have_link('Registered By : jdoe', href: search_path(tags: ['Registered By : jdoe']))
       expect(cells[1]).to have_button('Unpin')
     end
   end
@@ -33,6 +33,26 @@ RSpec.describe Dashboard::PinnedTagsTableComponent, type: :component do
       render_inline(component)
 
       expect(page).to have_text('No tags have been pinned.')
+    end
+  end
+
+  context 'when a pinned tag is a ticket tag' do
+    let(:pinned_tags) { [build(:pinned_tag, tag: 'Ticket : DIGREQ-123')] }
+
+    it 'links to the tickets facet search, with the prefix stripped' do
+      render_inline(component)
+
+      expect(page).to have_link('Ticket : DIGREQ-123', href: search_path(tickets: ['DIGREQ-123']))
+    end
+  end
+
+  context 'when a pinned tag is a project tag' do
+    let(:pinned_tags) { [build(:pinned_tag, tag: 'Project : Foo')] }
+
+    it 'links to the projects facet search, with the prefix stripped' do
+      render_inline(component)
+
+      expect(page).to have_link('Project : Foo', href: search_path(projects: ['Foo']))
     end
   end
 end

--- a/spec/components/dashboard/pinned_tags_table_component_spec.rb
+++ b/spec/components/dashboard/pinned_tags_table_component_spec.rb
@@ -1,0 +1,38 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe Dashboard::PinnedTagsTableComponent, type: :component do
+  include Rails.application.routes.url_helpers
+
+  let(:component) { described_class.new(pinned_tags:) }
+
+  context 'when there are pinned tags' do
+    let(:pinned_tags) { [build(:pinned_tag, tag: 'Project : Foo')] }
+
+    it 'renders a row for each pinned tag' do
+      render_inline(component)
+
+      table = page.find('table[aria-label="Pinned tags"]')
+      expect(table).to have_css('caption', text: 'Pinned tags')
+      expect(table).to have_css('caption .bi-pin-fill')
+      expect(table).to have_css('th', text: 'Tag')
+      expect(table).to have_css('th', text: 'Unpin')
+
+      row = table.find('tbody tr')
+      cells = row.all('td')
+      expect(cells[0]).to have_link('Project : Foo', href: search_path(tags: ['Project : Foo']))
+      expect(cells[1]).to have_button('Unpin')
+    end
+  end
+
+  context 'when there are no pinned tags' do
+    let(:pinned_tags) { [] }
+
+    it 'renders the empty message' do
+      render_inline(component)
+
+      expect(page).to have_text('No tags have been pinned.')
+    end
+  end
+end

--- a/spec/components/pin/pinned_tag_component_spec.rb
+++ b/spec/components/pin/pinned_tag_component_spec.rb
@@ -1,0 +1,58 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe Pin::PinnedTagComponent, type: :component do
+  include Rails.application.routes.url_helpers
+
+  let(:tag) { 'Project : Foo' }
+
+  context 'when not pinned' do
+    let(:component) { described_class.new(tag:, pinned: false) }
+
+    it 'renders a button that pins the tag' do
+      render_inline(component)
+
+      expect(page).to have_css('.bi-pin')
+      expect(page).to have_no_css('.bi-pin-fill')
+      expect(page).to have_css("form[action='#{pinned_tags_path}'][method='post']")
+      expect(page).to have_field('tag', type: 'hidden', with: tag)
+      expect(page).to have_button('Pin')
+    end
+  end
+
+  context 'when pinned' do
+    let(:component) { described_class.new(tag:, pinned: true) }
+
+    it 'renders a button that unpins the tag' do
+      render_inline(component)
+
+      expect(page).to have_css('.bi-pin-fill')
+      expect(page).to have_no_css('.bi-pin')
+      expect(page).to have_css("form[action='#{pinned_tag_path(tag)}']")
+      expect(page).to have_field('_method', type: 'hidden', with: 'delete')
+      expect(page).to have_button('Unpin')
+    end
+  end
+
+  context 'when not compact (the default)' do
+    let(:component) { described_class.new(tag:, pinned: true) }
+
+    it 'renders a larger icon to match the other pin buttons' do
+      render_inline(component)
+
+      expect(page).to have_css('.bi-pin-fill.fs-4')
+    end
+  end
+
+  context 'when compact' do
+    let(:component) { described_class.new(tag:, pinned: true, compact: true) }
+
+    it 'renders a smaller, tightly-padded button for dense lists' do
+      render_inline(component)
+
+      expect(page).to have_css('.bi-pin-fill:not(.fs-4)')
+      expect(page).to have_button('Unpin', class: 'p-0')
+    end
+  end
+end

--- a/spec/components/show/tag_component_spec.rb
+++ b/spec/components/show/tag_component_spec.rb
@@ -1,0 +1,53 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe Show::TagComponent, type: :component do
+  include Rails.application.routes.url_helpers
+
+  subject(:component) { described_class.new(tags:, pinned_tags:) }
+
+  let(:tags) { ['Registered By : ABC'] }
+  let(:pinned_tags) { Set.new }
+
+  it 'renders a link and pin button for each tag' do
+    render_inline(component)
+
+    expect(page).to have_css('h2', text: 'Tags')
+    tags.each do |tag|
+      expect(page).to have_link(tag, href: search_path(tags: [tag]))
+    end
+  end
+
+  context 'when there are no tags' do
+    let(:tags) { [] }
+
+    it 'renders the heading and no list items' do
+      render_inline(component)
+
+      expect(page).to have_css('h2', text: 'Tags')
+      expect(page).to have_no_css('li')
+    end
+  end
+
+  context 'when a tag is a ticket tag' do
+    let(:tags) { ['Ticket : DIGREQ-123'] }
+
+    it 'links to the tickets facet search, with the prefix stripped' do
+      render_inline(component)
+
+      expect(page).to have_link('Ticket : DIGREQ-123', href: search_path(tickets: ['DIGREQ-123']))
+    end
+  end
+
+  context 'when a tag is a project tag' do
+    let(:tags) { ['Project : XYZ'] }
+    let(:pinned_tags) { Set['Project : XYZ'] }
+
+    it 'links to the projects facet search, with the prefix stripped' do
+      render_inline(component)
+
+      expect(page).to have_link('Project : XYZ', href: search_path(projects: ['XYZ']))
+    end
+  end
+end

--- a/spec/requests/pinned_tags_spec.rb
+++ b/spec/requests/pinned_tags_spec.rb
@@ -1,0 +1,59 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe 'PinnedTags' do
+  let(:user) { create(:user) }
+  let(:tag) { 'Project : Foo' }
+
+  before do
+    sign_in(user)
+  end
+
+  describe 'POST /pinned_tags' do
+    it 'creates a pinned tag for the current user and shows a toast' do
+      expect do
+        post pinned_tags_path, params: { tag: }
+      end.to change(PinnedTag, :count).by(1)
+
+      expect(response).to redirect_to(root_path)
+      expect(response).to have_http_status(:see_other)
+      expect(flash[:toast]).to eq('Pin added')
+      expect(PinnedTag.last.user).to eq(user)
+      expect(PinnedTag.last.tag).to eq(tag)
+    end
+
+    it 'is idempotent when the tag is already pinned' do
+      PinnedTag.create!(user:, tag:)
+
+      expect do
+        post pinned_tags_path, params: { tag: }
+      end.not_to change(PinnedTag, :count)
+      expect(response).to have_http_status(:see_other)
+    end
+  end
+
+  describe 'DELETE /pinned_tags/:id' do
+    before { PinnedTag.create!(user:, tag:) }
+
+    it 'destroys the pinned tag and shows a toast' do
+      expect do
+        delete pinned_tag_path(tag)
+      end.to change(PinnedTag, :count).by(-1)
+
+      expect(response).to redirect_to(root_path)
+      expect(response).to have_http_status(:see_other)
+      expect(flash[:toast]).to eq('Pin removed')
+    end
+
+    it 'does not destroy a pinned tag belonging to another user' do
+      sign_in(create(:user))
+
+      expect do
+        delete pinned_tag_path(tag)
+      end.not_to change(PinnedTag, :count)
+
+      expect(response).to have_http_status(:not_found)
+    end
+  end
+end

--- a/spec/requests/pinned_tags_spec.rb
+++ b/spec/requests/pinned_tags_spec.rb
@@ -45,15 +45,5 @@ RSpec.describe 'PinnedTags' do
       expect(response).to have_http_status(:see_other)
       expect(flash[:toast]).to eq('Pin removed')
     end
-
-    it 'does not destroy a pinned tag belonging to another user' do
-      sign_in(create(:user))
-
-      expect do
-        delete pinned_tag_path(tag)
-      end.not_to change(PinnedTag, :count)
-
-      expect(response).to have_http_status(:not_found)
-    end
   end
 end

--- a/spec/system/pin_tag_spec.rb
+++ b/spec/system/pin_tag_spec.rb
@@ -48,7 +48,7 @@ RSpec.describe 'Pin and unpin a tag' do
     visit "/objects/#{druid}"
 
     within('.card', text: 'Tags') do
-      expect(page).to have_link('Project : Foo', href: search_path(tags: ['Project : Foo']))
+      expect(page).to have_link('Project : Foo', href: search_path(projects: ['Foo']))
       expect(page).to have_button('Pin')
 
       click_button 'Pin'
@@ -62,7 +62,7 @@ RSpec.describe 'Pin and unpin a tag' do
 
     visit root_path
 
-    expect(page).to have_link('Project : Foo', href: search_path(tags: ['Project : Foo']))
+    expect(page).to have_link('Project : Foo', href: search_path(projects: ['Foo']))
     expect(page).to have_button('Unpin')
 
     click_button 'Unpin'

--- a/spec/system/pin_tag_spec.rb
+++ b/spec/system/pin_tag_spec.rb
@@ -1,0 +1,74 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe 'Pin and unpin a tag' do
+  let(:druid) { 'druid:bb123cd4567' }
+  let(:apo_druid) { 'druid:cc123cd4578' }
+  let(:title) { 'My agreement title' }
+
+  let(:object_client) do
+    instance_double(Dor::Services::Client::Object, version: version_client, milestones: milestones_client,
+                                                   user_version: user_version_client, lock: 'lock1')
+  end
+  let(:version_client) { instance_double(Dor::Services::Client::ObjectVersion, inventory: [], status: version_status) }
+  let(:version_status) do
+    instance_double(Dor::Services::Client::ObjectVersion::VersionStatus, accessioning?: true, closed?: true)
+  end
+  let(:user_version_client) { instance_double(Dor::Services::Client::UserVersion, inventory: []) }
+  let(:milestones_client) { instance_double(Dor::Services::Client::Milestones, list: []) }
+
+  let(:solr_doc) do
+    {
+      Search::Fields::ID => druid,
+      Search::Fields::OBJECT_TYPES => ['agreement'],
+      Search::Fields::CONTENT_TYPES => ['agreement'],
+      Search::Fields::TITLE => title,
+      Search::Fields::APO_DRUID => [apo_druid],
+      Search::Fields::APO_TITLE => ['My APO'],
+      Search::Fields::COLLECTION_DRUIDS => [],
+      Search::Fields::COLLECTION_TITLES => [],
+      Search::Fields::OTHER_TAGS => ['Project : Foo']
+    }
+  end
+
+  let(:cocina_object) do
+    build(:agreement_with_metadata, id: druid, admin_policy_id: apo_druid, title:)
+  end
+
+  before do
+    allow(Dor::Services::Client).to receive(:object).with(druid).and_return(object_client)
+    allow(Sdr::WorkflowService).to receive(:workflows_for).and_return([])
+    allow(Sdr::Repository).to receive_messages(find_solr: solr_doc, find: cocina_object)
+
+    sign_in(create(:user))
+  end
+
+  it 'pins from the object show page and unpins from the dashboard' do
+    visit "/objects/#{druid}"
+
+    within('.card', text: 'Tags') do
+      expect(page).to have_link('Project : Foo', href: search_path(tags: ['Project : Foo']))
+      expect(page).to have_button('Pin')
+
+      click_button 'Pin'
+    end
+
+    within('.card', text: 'Tags') do
+      expect(page).to have_button('Unpin')
+      expect(page).to have_no_button('Pin')
+    end
+    expect(page).to have_toast('Pin added')
+
+    visit root_path
+
+    expect(page).to have_link('Project : Foo', href: search_path(tags: ['Project : Foo']))
+    expect(page).to have_button('Unpin')
+
+    click_button 'Unpin'
+
+    expect(page).to have_no_link('Project : Foo')
+    expect(page).to have_text('No tags have been pinned.')
+    expect(page).to have_toast('Pin removed')
+  end
+end

--- a/spec/system/show_admin_policy_spec.rb
+++ b/spec/system/show_admin_policy_spec.rb
@@ -28,7 +28,7 @@ RSpec.describe 'Show admin policy' do
       Search::Fields::TITLE => title,
       Search::Fields::APO_DRUID => [apo_druid],
       Search::Fields::APO_TITLE => ['My APO'],
-      Search::Fields::OTHER_TAGS => ['Registered By : jdoe', 'Remediated By : labtech'],
+      Search::Fields::OTHER_TAGS => ['Registered By : jdoe', 'Remediated By : labtech', 'Ticket : TESTREQ-1'],
       Search::Fields::TICKETS => ['TESTREQ-1']
     }
   end
@@ -92,7 +92,7 @@ RSpec.describe 'Show admin policy' do
 
     # Tags card
     within('.card', text: 'Tags') do
-      expect(page).to have_css('li', text: 'TESTREQ-1')
+      expect(page).to have_css('li', text: 'Ticket : TESTREQ-1')
       expect(page).to have_css('li', text: 'Registered By : jdoe')
       expect(page).to have_css('li', text: 'Remediated By : labtech')
     end

--- a/spec/system/show_collection_spec.rb
+++ b/spec/system/show_collection_spec.rb
@@ -32,7 +32,7 @@ RSpec.describe 'Show collection' do
       Search::Fields::APO_TITLE => ['My APO'],
       Search::Fields::SOURCE_ID => 'googlebooks:stanford_36105114203446',
       Search::Fields::CATALOG_RECORD_ID => ['a6525053'],
-      Search::Fields::OTHER_TAGS => ['Registered By : jdoe', 'Remediated By : labtech'],
+      Search::Fields::OTHER_TAGS => ['Registered By : jdoe', 'Remediated By : labtech', 'Ticket : TESTREQ-1'],
       Search::Fields::TICKETS => ['TESTREQ-1']
     }
   end
@@ -114,7 +114,7 @@ RSpec.describe 'Show collection' do
 
     # Tags card
     within('.card', text: 'Tags') do
-      expect(page).to have_css('li', text: 'TESTREQ-1')
+      expect(page).to have_css('li', text: 'Ticket : TESTREQ-1')
       expect(page).to have_css('li', text: 'Registered By : jdoe')
       expect(page).to have_css('li', text: 'Remediated By : labtech')
     end

--- a/spec/system/show_item_spec.rb
+++ b/spec/system/show_item_spec.rb
@@ -439,20 +439,44 @@ RSpec.describe 'Show item' do
       expect(page).to have_no_css('td.text-danger', text: 'Error: Bag validation failed')
     end
 
-    # Pinning and unpinning
-    expect(page).to have_css('.bi-pin')
-    expect(page).to have_no_css('.bi-pin-fill')
+    # Pinning and unpinning the object
+    within('h1') do
+      expect(page).to have_css('.bi-pin')
+      expect(page).to have_no_css('.bi-pin-fill')
 
-    find('.bi-pin').click
+      find('.bi-pin').click
+    end
 
     expect(page).to have_toast('Pin added')
-    expect(page).to have_css('.bi-pin-fill')
-    expect(page).to have_no_css('.bi-pin')
+    within('h1') do
+      expect(page).to have_css('.bi-pin-fill')
+      expect(page).to have_no_css('.bi-pin')
 
-    find('.bi-pin-fill').click
+      find('.bi-pin-fill').click
+    end
 
     expect(page).to have_toast('Pin removed')
-    expect(page).to have_css('.bi-pin')
-    expect(page).to have_no_css('.bi-pin-fill')
+    within('h1') do
+      expect(page).to have_css('.bi-pin')
+      expect(page).to have_no_css('.bi-pin-fill')
+    end
+
+    # Pinning and unpinning a tag
+    within('.card', text: 'Tags') do
+      within('li', text: 'TESTREQ-1') do
+        expect(page).to have_css('.bi-pin')
+        expect(page).to have_no_css('.bi-pin-fill')
+
+        find('.bi-pin').click
+      end
+    end
+
+    expect(page).to have_toast('Pin added')
+    within('.card', text: 'Tags') do
+      within('li', text: 'TESTREQ-1') do
+        expect(page).to have_css('.bi-pin-fill')
+        expect(page).to have_no_css('.bi-pin')
+      end
+    end
   end
 end

--- a/spec/system/show_item_spec.rb
+++ b/spec/system/show_item_spec.rb
@@ -93,7 +93,7 @@ RSpec.describe 'Show item' do
       Search::Fields::FORMATTED_REGISTERED_EARLIEST_DATE => '2025-01-08',
       Search::Fields::FORMATTED_DEPOSITED_LATEST_DATE => last_deposited,
       Search::Fields::FORMATTED_EMBARGO_RELEASE_DATE => '2040-06-15 12:00:00 PM',
-      Search::Fields::OTHER_TAGS => ['Registered By : jdoe', 'Remediated By : labtech'],
+      Search::Fields::OTHER_TAGS => ['Registered By : jdoe', 'Remediated By : labtech', 'Ticket : TESTREQ-1'],
       Search::Fields::TICKETS => ['TESTREQ-1']
     }
   end
@@ -291,7 +291,7 @@ RSpec.describe 'Show item' do
 
     # Tags card
     within('.card', text: 'Tags') do
-      expect(page).to have_css('li', text: 'TESTREQ-1')
+      expect(page).to have_css('li', text: 'Ticket : TESTREQ-1')
       expect(page).to have_css('li', text: 'Registered By : jdoe')
       expect(page).to have_css('li', text: 'Remediated By : labtech')
     end
@@ -463,7 +463,7 @@ RSpec.describe 'Show item' do
 
     # Pinning and unpinning a tag
     within('.card', text: 'Tags') do
-      within('li', text: 'TESTREQ-1') do
+      within('li', text: 'Ticket : TESTREQ-1') do
         expect(page).to have_css('.bi-pin')
         expect(page).to have_no_css('.bi-pin-fill')
 
@@ -473,7 +473,7 @@ RSpec.describe 'Show item' do
 
     expect(page).to have_toast('Pin added')
     within('.card', text: 'Tags') do
-      within('li', text: 'TESTREQ-1') do
+      within('li', text: 'Ticket : TESTREQ-1') do
         expect(page).to have_css('.bi-pin-fill')
         expect(page).to have_no_css('.bi-pin')
       end


### PR DESCRIPTION
Closes #277. I did not realize that the box on the Show page was ticketed separately in #253. This closes #253 and closes #278 as well, although I see in #253 that it says to pull the tags in from DSA. I'm not sure why, except to avoid the tag parsing for various types that happens in this PR?

<img width="1098" height="321" alt="Screenshot 2026-08-26 at 5 13 23 PM" src="https://github.com/user-attachments/assets/cdd7de13-d191-420d-af4d-50158fd89e47" />

Items:
<img width="334" height="208" alt="Screenshot 2026-08-26 at 5 12 02 PM" src="https://github.com/user-attachments/assets/19f08769-888f-478a-8b11-26babeb4436a" />

Collection:
<img width="326" height="208" alt="Screenshot 2026-08-26 at 5 13 15 PM" src="https://github.com/user-attachments/assets/19017163-31af-4d4b-9229-54595c0acca6" />

APO:
<img width="328" height="212" alt="Screenshot 2026-08-26 at 5 12 55 PM" src="https://github.com/user-attachments/assets/b268228e-2a5c-418d-8353-2a8a6a05e953" />

