### PR TITLE
Tabs as delimiter in bulk action logs

### DIFF
--- a/app/jobs/bulk_actions/base_csv_job.rb
+++ b/app/jobs/bulk_actions/base_csv_job.rb
@@ -36,12 +36,12 @@ module BulkActions
 
     def success!(druid:, message:, index:)
       bulk_action.increment(:druid_count_success).save
-      log(" - line #{index} - #{message} for #{druid}")
+      log(delimited_log_message(message:, index:, druid:))
     end
 
     def failure!(druid:, message:, index:)
       bulk_action.increment(:druid_count_fail).save
-      log(" - line #{index} - #{message} for #{druid}")
+      log(delimited_log_message(message:, index:, druid:))
     end
 
     private

--- a/app/jobs/bulk_actions/base_job.rb
+++ b/app/jobs/bulk_actions/base_job.rb
@@ -47,7 +47,12 @@ module BulkActions
     end
 
     def log(message)
-      log_file.puts("#{format_datetime(Time.zone.now)} #{message}")
+      log_file.puts("#{format_datetime(Time.zone.now)}\t#{message}")
+    end
+
+    # Builds a tab-delimited log message
+    def delimited_log_message(message:, index: nil, druid: nil)
+      [("line #{index}" if index), druid, message].compact.join("\t")
     end
 
     # Subclasses must implement.

--- a/app/jobs/bulk_actions/base_job.rb
+++ b/app/jobs/bulk_actions/base_job.rb
@@ -52,7 +52,7 @@ module BulkActions
 
     # Builds a tab-delimited log message
     def delimited_log_message(message:, index: nil, druid: nil)
-      [("line #{index}" if index), druid, message].compact.join("\t")
+      [index && "line #{index}", druid, message].join("\t")
     end
 
     # Subclasses must implement.

--- a/app/jobs/bulk_actions/druids_job.rb
+++ b/app/jobs/bulk_actions/druids_job.rb
@@ -35,12 +35,12 @@ module BulkActions
 
     def success!(druid:, message: nil)
       bulk_action.increment(:druid_count_success)
-      log("#{message} for #{druid}") if message
+      log(delimited_log_message(message:, druid:)) if message
     end
 
     def failure!(druid:, message:)
       bulk_action.increment(:druid_count_fail)
-      log("#{message} for #{druid}")
+      log(delimited_log_message(message:, druid:))
     end
   end
 end

--- a/app/jobs/bulk_actions/register_job.rb
+++ b/app/jobs/bulk_actions/register_job.rb
@@ -21,18 +21,12 @@ module BulkActions
 
     def success!(message:, index:, druid: nil)
       bulk_action.increment(:druid_count_success).save
-      log(log_msg(message:, index:, druid:))
+      log(delimited_log_message(message:, index:, druid:))
     end
 
     def failure!(message:, index:, druid: nil)
       bulk_action.increment(:druid_count_fail).save
-      log(log_msg(message:, index:, druid:))
-    end
-
-    def log_msg(message:, index:, druid: nil)
-      msg = " - line #{index} - #{message}"
-      msg += " for #{druid}" if druid
-      msg
+      log(delimited_log_message(message:, index:, druid:))
     end
 
     def druid_count

--- a/spec/jobs/bulk_actions/apply_apo_defaults_job_spec.rb
+++ b/spec/jobs/bulk_actions/apply_apo_defaults_job_spec.rb
@@ -38,7 +38,7 @@ RSpec.describe BulkActions::ApplyApoDefaultsJob do
     expect(object_client).to have_received(:apply_admin_policy_defaults)
     expect(job_item).to have_received(:close_version_if_needed!)
 
-    expect(log).to have_received(:puts).with(/Successfully applied defaults for druid:bb111cc2222/)
+    expect(log).to have_received(:puts).with(/druid:bb111cc2222\tSuccess: Successfully applied defaults/)
   end
 
   context 'when not authorized to update' do

--- a/spec/jobs/bulk_actions/base_csv_job_spec.rb
+++ b/spec/jobs/bulk_actions/base_csv_job_spec.rb
@@ -55,8 +55,8 @@ RSpec.describe BulkActions::BaseCsvJob do
 
       expect(log).to have_received(:puts).with(/Starting TestBulkActionCsvJob for BulkAction #{bulk_action.id}/)
       expect(log).to have_received(:puts).with(/Finished TestBulkActionCsvJob for BulkAction #{bulk_action.id}/)
-      expect(log).to have_received(:puts).with(/line 2 - Success: Testing successful for #{druids.first}/o)
-      expect(log).to have_received(:puts).with(/line 3 - Error: Testing failed for #{druids.second}/o)
+      expect(log).to have_received(:puts).with(/line 2\t#{druids.first}\tSuccess: Testing successful/o)
+      expect(log).to have_received(:puts).with(/line 3\t#{druids.second}\tError: Testing failed/o)
 
       expect(bulk_action.reload.druid_count_total).to eq(2)
       expect(bulk_action.druid_count_success).to eq(1)

--- a/spec/jobs/bulk_actions/druids_job_spec.rb
+++ b/spec/jobs/bulk_actions/druids_job_spec.rb
@@ -50,10 +50,10 @@ RSpec.describe BulkActions::DruidsJob do
                                                                      job: instance_of(TestBulkActionJob))
 
       expect(log).to have_received(:puts)
-        .with("2026-07-29 14:56:58 PT Starting TestBulkActionJob for BulkAction #{bulk_action.id}")
+        .with("2026-07-29 14:56:58 PT\tStarting TestBulkActionJob for BulkAction #{bulk_action.id}")
       expect(log).to have_received(:puts).with(/Finished TestBulkActionJob for BulkAction #{bulk_action.id}/)
-      expect(log).to have_received(:puts).with(/Success: Testing successful for #{druids.first}/o)
-      expect(log).to have_received(:puts).with(/Error: Testing failed for #{druids.second}/o)
+      expect(log).to have_received(:puts).with(/#{druids.first}\tSuccess: Testing successful/o)
+      expect(log).to have_received(:puts).with(/#{druids.second}\tError: Testing failed/o)
       expect(log).to have_received(:close)
       expect(export_file).to have_received(:close)
 
@@ -88,8 +88,8 @@ RSpec.describe BulkActions::DruidsJob do
     it 'performs the job' do
       TestBulkActionJob.perform_now(bulk_action:, druids:)
 
-      expect(log).to have_received(:puts).with(/Success: Testing successful for #{druids.first}/o)
-      expect(log).to have_received(:puts).with(/Error: StandardError Something bad happened for #{druids.second}/o)
+      expect(log).to have_received(:puts).with(/#{druids.first}\tSuccess: Testing successful/o)
+      expect(log).to have_received(:puts).with(/#{druids.second}\tError: StandardError Something bad happened/o)
 
       expect(bulk_action.reload.druid_count_total).to eq(2)
       expect(bulk_action.druid_count_success).to eq(1)

--- a/spec/jobs/bulk_actions/export_catalog_data_job_spec.rb
+++ b/spec/jobs/bulk_actions/export_catalog_data_job_spec.rb
@@ -41,7 +41,7 @@ RSpec.describe BulkActions::ExportCatalogDataJob do
     expect(bulk_action.druid_count_success).to eq(1)
     expect(bulk_action.druid_count_fail).to eq(0)
 
-    expect(log.string).to include "Exported catalog data for #{druid}"
+    expect(log.string).to include "#{druid}\tSuccess: Exported catalog data"
 
     expect(File).to exist(bulk_action.export_filepath)
     csv = CSV.read(bulk_action.export_filepath, headers: true)
@@ -115,7 +115,7 @@ RSpec.describe BulkActions::ExportCatalogDataJob do
 
       expect(bulk_action.reload.druid_count_fail).to eq(1)
       expect(bulk_action.druid_count_success).to eq(0)
-      expect(log.string).to include "Sdr::Repository::NotFoundResponse Object not found: #{druid} for #{druid}"
+      expect(log.string).to include "#{druid}\tError: Sdr::Repository::NotFoundResponse Object not found: #{druid}"
     end
   end
 end

--- a/spec/jobs/bulk_actions/export_descriptive_metadata_job_spec.rb
+++ b/spec/jobs/bulk_actions/export_descriptive_metadata_job_spec.rb
@@ -70,7 +70,7 @@ RSpec.describe BulkActions::ExportDescriptiveMetadataJob do
       expect(bulk_action.druid_count_fail).to eq(1)
       expect(bulk_action.druid_count_total).to eq(3)
 
-      expect(log).to have_received(:puts).with(/Failed NoMethodError .+ for #{druid3}/).once
+      expect(log).to have_received(:puts).with(/#{druid3}\tFailed NoMethodError/).once
     end
   end
 
@@ -86,7 +86,7 @@ RSpec.describe BulkActions::ExportDescriptiveMetadataJob do
       expect(bulk_action.druid_count_fail).to eq(1)
       expect(bulk_action.druid_count_total).to eq(3)
 
-      expect(log).to have_received(:puts).with(/Could not find object for #{druid3}/).once
+      expect(log).to have_received(:puts).with(/#{druid3}\tCould not find object/).once
     end
   end
 
@@ -103,7 +103,7 @@ RSpec.describe BulkActions::ExportDescriptiveMetadataJob do
       expect(bulk_action.druid_count_fail).to eq(1)
       expect(bulk_action.druid_count_total).to eq(3)
 
-      expect(log).to have_received(:puts).with(/Could not request object for #{druid3}/).once
+      expect(log).to have_received(:puts).with(/#{druid3}\tCould not request object/).once
     end
   end
 end

--- a/spec/jobs/bulk_actions/export_structural_metadata_job_spec.rb
+++ b/spec/jobs/bulk_actions/export_structural_metadata_job_spec.rb
@@ -193,7 +193,7 @@ RSpec.describe BulkActions::ExportStructuralMetadataJob do
     expect(bulk_action.druid_count_success).to eq(1)
     expect(bulk_action.druid_count_fail).to eq(0)
 
-    expect(log.string).to include "Exported structural metadata for #{druid}"
+    expect(log.string).to include "#{druid}\tSuccess: Exported structural metadata"
 
     expect(File).to exist(bulk_action.export_filepath)
     output = CSV.read(bulk_action.export_filepath, headers: true)
@@ -208,7 +208,7 @@ RSpec.describe BulkActions::ExportStructuralMetadataJob do
       job.perform_now
 
       expect(bulk_action.reload.druid_count_fail).to eq(1)
-      expect(log.string).to include "No structural metadata to export for #{druid}"
+      expect(log.string).to include "#{druid}\tError: No structural metadata to export"
 
       expect(File).to exist(bulk_action.export_filepath)
       File.open(bulk_action.export_filepath, 'r') do |file|

--- a/spec/jobs/bulk_actions/manage_content_type_job_spec.rb
+++ b/spec/jobs/bulk_actions/manage_content_type_job_spec.rb
@@ -75,7 +75,7 @@ RSpec.describe BulkActions::ManageContentTypeJob do
       end
       expect(job_item).to have_received(:close_version_if_needed!)
 
-      expect(log.string).to include('Successfully updated content type for')
+      expect(log.string).to include("#{druid}\tSuccess: Successfully updated content type")
       expect(bulk_action.reload.druid_count_total).to eq(1)
       expect(bulk_action.druid_count_success).to eq(1)
       expect(bulk_action.druid_count_fail).to eq(0)
@@ -206,7 +206,7 @@ RSpec.describe BulkActions::ManageContentTypeJob do
 
       expect(job_item).not_to have_received(:open_new_version_if_needed!)
       expect(Sdr::Repository).not_to have_received(:update)
-      expect(log.string).to include('No changes made for')
+      expect(log.string).to include("#{druid}\tSuccess: No changes made")
 
       expect(bulk_action.reload.druid_count_total).to eq(1)
       expect(bulk_action.druid_count_success).to eq(1)

--- a/spec/jobs/bulk_actions/manage_license_and_rights_statements_job_spec.rb
+++ b/spec/jobs/bulk_actions/manage_license_and_rights_statements_job_spec.rb
@@ -98,7 +98,7 @@ RSpec.describe BulkActions::ManageLicenseAndRightsStatementsJob do
 
       expect(job_item).not_to have_received(:open_new_version_if_needed!)
       expect(Sdr::Repository).not_to have_received(:update)
-      expect(log.string).to include('No changes made for')
+      expect(log.string).to include("#{druid}\tSuccess: No changes made")
 
       expect(bulk_action.reload.druid_count_total).to eq(1)
       expect(bulk_action.druid_count_success).to eq(1)

--- a/spec/jobs/bulk_actions/manage_rights_job_spec.rb
+++ b/spec/jobs/bulk_actions/manage_rights_job_spec.rb
@@ -137,7 +137,7 @@ RSpec.describe BulkActions::ManageRightsJob do
 
       expect(job_item).not_to have_received(:open_new_version_if_needed!)
       expect(Sdr::Repository).not_to have_received(:update)
-      expect(log.string).to include('No changes made for')
+      expect(log.string).to include("#{druid}\tSuccess: No changes made")
 
       expect(bulk_action.reload.druid_count_total).to eq(1)
       expect(bulk_action.druid_count_success).to eq(1)

--- a/spec/jobs/bulk_actions/refresh_metadata_job_spec.rb
+++ b/spec/jobs/bulk_actions/refresh_metadata_job_spec.rb
@@ -70,7 +70,7 @@ RSpec.describe BulkActions::RefreshMetadataJob do
 
       expect(object_client).not_to have_received(:refresh_descriptive_metadata_from_ils)
 
-      expect(log).to have_received(:puts).with(/Does not have a Folio Instance HRID for #{druid}/)
+      expect(log).to have_received(:puts).with(/#{druid}\tError: Does not have a Folio Instance HRID/)
 
       expect(bulk_action.reload.druid_count_total).to eq(1)
       expect(bulk_action.druid_count_fail).to eq(1)
@@ -93,7 +93,7 @@ RSpec.describe BulkActions::RefreshMetadataJob do
 
       expect(object_client).not_to have_received(:refresh_descriptive_metadata_from_ils)
 
-      expect(log).to have_received(:puts).with(/Refresh is set to false for #{druid}/)
+      expect(log).to have_received(:puts).with(/#{druid}\tError: Refresh is set to false/)
 
       expect(bulk_action.reload.druid_count_total).to eq(1)
       expect(bulk_action.druid_count_fail).to eq(1)

--- a/spec/jobs/bulk_actions/register_job_spec.rb
+++ b/spec/jobs/bulk_actions/register_job_spec.rb
@@ -95,7 +95,7 @@ RSpec.describe BulkActions::RegisterJob do
               tags: [],
               workflow_name: 'accessionWF',
               user_name:)
-      expect(log).to have_received(:puts).with(/Registration successful for druid:df123df4567/).twice
+      expect(log).to have_received(:puts).with(/druid:df123df4567\tRegistration successful/).twice
       expect(bulk_action.druid_count_success).to eq 2
       expect(File.read(csv_filepath)).to eq("Druid,Barcode,Folio Instance HRID,Source Id,Title\ndf123df4567,36105010101010,in12345,foo:bar1,factory DRO title\ndf123df4567,36105010101010,in12345,foo:bar1,factory DRO title\n") # rubocop:disable Layout/LineLength
     end
@@ -132,7 +132,7 @@ RSpec.describe BulkActions::RegisterJob do
               tags: ['csv : test', 'Project : two'],
               workflow_name: 'accessionWF',
               user_name:).twice
-      expect(log).to have_received(:puts).with(/Registration successful for druid:df123df4567/).twice
+      expect(log).to have_received(:puts).with(/druid:df123df4567\tRegistration successful/).twice
       expect(bulk_action.druid_count_success).to eq 2
     end
   end
@@ -159,7 +159,7 @@ RSpec.describe BulkActions::RegisterJob do
               tags: [],
               workflow_name: 'accessionWF',
               user_name:)
-      expect(log).to have_received(:puts).with(/Registration successful for druid:df123df4567/).twice
+      expect(log).to have_received(:puts).with(/druid:df123df4567\tRegistration successful/).twice
       expect(bulk_action.druid_count_success).to eq 2
     end
   end

--- a/spec/jobs/bulk_actions/reindex_job_spec.rb
+++ b/spec/jobs/bulk_actions/reindex_job_spec.rb
@@ -51,10 +51,10 @@ RSpec.describe BulkActions::ReindexJob do
         expect(bulk_action.reload.druid_count_success).to eq 1
         expect(bulk_action.druid_count_fail).to eq 2
 
-        expect(log.string).to include "Reindex successful for #{druids[0]}"
-        expect(log.string).to include "Error: StandardError StandardError for #{druids[1]}"
-        expect(log.string).to include 'Error: Dor::Services::Client::ConnectionFailed ' \
-                                      "Dor::Services::Client::ConnectionFailed for #{druids[2]}"
+        expect(log.string).to include "#{druids[0]}\tSuccess: Reindex successful"
+        expect(log.string).to include "#{druids[1]}\tError: StandardError StandardError"
+        expect(log.string).to include "#{druids[2]}\tError: Dor::Services::Client::ConnectionFailed " \
+                                      'Dor::Services::Client::ConnectionFailed'
       end
     end
   end


### PR DESCRIPTION
Fixes #378 - use tabs instead of commas as a delimiter in the bulk job logs

the actual code changes are minimal, most of the changes in the specs to show that we have tabs now in the logs