### PR TITLE
reorder/adjust left-nav on item show page

### DIFF
--- a/app/views/objects/show.html.erb
+++ b/app/views/objects/show.html.erb
@@ -35,17 +35,19 @@
         <p><%= link_to_purl(@solr_doc.druid) %></p>
       <% end %>
       <%= render Elements::ButtonListComponent.new(title: 'Actions', help_text: '(does not require new version)') do |component| %>
+        <% component.with_button(link: '/', label: 'Use as template', variant: 'outline-primary', disabled: true) %>
+        <% component.with_button(link: '/', label: 'Download description', variant: 'outline-primary', disabled: true) %>
+        <% component.with_button(link: '/', label: 'Download structural CSV', variant: 'outline-primary', disabled: true) %>
         <% component.with_button(link: '/', label: 'Reindex', variant: 'outline-primary', disabled: true) %>
         <% component.with_button(link: '/', label: 'Republish', variant: 'outline-primary', disabled: true) %>
-        <% component.with_button(link: '/', label: 'Add workflow', variant: 'outline-primary', disabled: true) %>
       <% end %>
 
       <%= render Elements::ButtonListComponent.new(title: 'Edit', help_text: '(requires new version)', classes: 'mt-4') do |component| %>
-        <% component.with_button(link: '/', label: 'Manage files', variant: 'outline-primary', disabled: true) %>
-        <% component.with_button(link: '/', label: 'Manage description', variant: 'outline-primary', disabled: true) %>
-        <% component.with_button(link: '/', label: 'Text extraction', variant: 'outline-primary', disabled: true) %>
         <% component.with_button(link: '/', label: 'Apply APO defaults', variant: 'outline-primary', disabled: true) %>
-        <% component.with_button(link: '/', label: 'Manage embargo', variant: 'outline-primary', disabled: true) %>
+        <% component.with_button(link: '/', label: 'Extract text', variant: 'outline-primary', disabled: true) %>
+        <% component.with_button(link: '/', label: 'Add embargo', variant: 'outline-primary', disabled: true) %>
+        <% component.with_button(link: '/', label: 'Add workflow', variant: 'outline-primary', disabled: true) %>
+        <% component.with_button(link: '/', label: 'Refresh from FOLIO', variant: 'outline-primary', disabled: true) %>
       <% end %>
 
       <%= render Elements::ButtonListComponent.new(title: 'Discard', classes: 'mt-4') do |component| %>


### PR DESCRIPTION
Fixes #350.

Note: actions are unimplemented, so these are not linked yet.  It just makes them match the design/order in the ticket.