### PR TITLE
add content type selector to single item registration form

### DIFF
--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -45,8 +45,8 @@ class ItemsController < ApplicationController
 
   def item_form_params
     params.permit(item: ItemForm.permitted_params)[:item]
-          # Hardcoding for now since required
-          .merge(access_view: 'world', access_download: 'world', content_type: Cocina::Models::ObjectType.object)
+          # Hardcoding access for now since required
+          .merge(access_view: 'world', access_download: 'world')
   end
 
   def set_apo_options

--- a/app/services/constants.rb
+++ b/app/services/constants.rb
@@ -117,5 +117,19 @@ module Constants # rubocop:disable Metrics/ModuleLength
 
   CONTENT_TYPES = Cocina::Models::DRO::TYPES.index_by { |uri| uri.split('/').last }.freeze
 
+  # content types selectable by the user on a registration form
+  REGISTRATION_CONTENT_TYPES = {
+    'book' => Cocina::Models::ObjectType.book,
+    'file' => Cocina::Models::ObjectType.object,
+    'image' => Cocina::Models::ObjectType.image,
+    'map' => Cocina::Models::ObjectType.map,
+    'media' => Cocina::Models::ObjectType.media,
+    '3d' => Cocina::Models::ObjectType.three_dimensional,
+    'document' => Cocina::Models::ObjectType.document,
+    'geo' => Cocina::Models::ObjectType.geo,
+    'webarchive-binary' => Cocina::Models::ObjectType.webarchive_binary,
+    'webarchive-seed' => Cocina::Models::ObjectType.webarchive_seed
+  }.freeze
+
   RESOURCE_TYPES = Cocina::Models::FileSet::TYPES.index_by { |uri| uri.split('/').last }.freeze
 end

--- a/app/views/items/new.html.erb
+++ b/app/views/items/new.html.erb
@@ -24,7 +24,7 @@
                                                                    container_classes: 'mb-3') %>
 
         <%= render SdrViewComponents::Forms::SelectFieldComponent.new(form:, field_name: :content_type,
-                                                                      options: Constants::CONTENT_TYPES,
+                                                                      options: Constants::REGISTRATION_CONTENT_TYPES,
                                                                       label_text: t('edit.items.fields.content_type.label'),
                                                                       label_mark_required: true,
                                                                       label_classes: 'fw-bold') %>

--- a/app/views/items/new.html.erb
+++ b/app/views/items/new.html.erb
@@ -22,6 +22,12 @@
                                                                    label_mark_required: true,
                                                                    label_classes: 'fw-bold',
                                                                    container_classes: 'mb-3') %>
+
+        <%= render SdrViewComponents::Forms::SelectFieldComponent.new(form:, field_name: :content_type,
+                                                                      options: Constants::CONTENT_TYPES,
+                                                                      label_text: t('edit.items.fields.content_type.label'),
+                                                                      label_mark_required: true,
+                                                                      label_classes: 'fw-bold') %>
       <% end %>
 
       <% tab_list.with_pane(SdrViewComponents::TabForm::PaneComponent.new(tab_name: :rights,

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -130,6 +130,8 @@ en:
       fields:
         admin_policy_druid:
           label: "APO"
+        content_type:
+          label: "Content type"
         source_id:
           label: "Source ID"
         source_id_prefix:

--- a/spec/system/create_item_spec.rb
+++ b/spec/system/create_item_spec.rb
@@ -50,6 +50,7 @@ RSpec.describe 'Create an item' do
 
       fill_in 'Source ID', with: 'new:source-id'
       fill_in 'Title', with: 'The Title'
+      select 'image', from: 'Content type'
 
       find_by_id('rights-tab').click
       select apo_title, from: 'APO'
@@ -67,7 +68,7 @@ RSpec.describe 'Create an item' do
       expect(Sdr::Repository).to have_received(:register) do |args|
         request_cocina_object = args[:request_cocina_object]
         expect(request_cocina_object).to be_a(Cocina::Models::RequestDRO)
-        expect(request_cocina_object.type).to eq(Cocina::Models::ObjectType.object)
+        expect(request_cocina_object.type).to eq(Cocina::Models::ObjectType.image)
         expect(request_cocina_object.identification.sourceId).to eq('new:source-id')
         expect(request_cocina_object.administrative.hasAdminPolicy).to eq(apo_druid)
         expect(request_cocina_object.description.title.first.value).to eq('The Title')
@@ -112,6 +113,7 @@ RSpec.describe 'Create an item' do
 
       fill_in 'Source ID', with: 'new:source-id'
       fill_in 'Title', with: 'The Title'
+      select 'book', from: 'Content type'
 
       find_by_id('rights-tab').click
       select apo_title, from: 'APO'
@@ -122,7 +124,10 @@ RSpec.describe 'Create an item' do
       expect(page).to have_current_path(edit_content_path(druid))
       expect(page).to have_toast('Item registered.')
 
-      expect(Sdr::Repository).to have_received(:register)
+      expect(Sdr::Repository).to have_received(:register) do |args|
+        request_cocina_object = args[:request_cocina_object]
+        expect(request_cocina_object.type).to eq(Cocina::Models::ObjectType.book)
+      end
       expect(Sdr::Repository).not_to have_received(:accession)
     end
   end


### PR DESCRIPTION
Fixes #296. Adds a drop down menu to select content type when registering a new single object.  See screenshot below.

~~Note: I used the existing CONTENT_TYPES already defined in argo-b3 constants (see https://github.com/sul-dlss/argo-b3/blob/main/app/services/constants.rb#L118) which are dynamically set from Cocina Models, instead of copying from Argo (see https://github.com/sul-dlss/argo/blob/main/app/forms/content_type_form.rb#L9-L20), as described in the ticket.~~

~~This adds extra content types to the menu though beyond what is currently in Argo, and also has a different order.  If we really want just the set currently in Argo, we can create a new constant just for this drop down menu.~~

<img width="1267" height="541" alt="Screenshot 2026-08-28 at 1 54 29 PM" src="https://github.com/user-attachments/assets/ece69c63-bce2-4add-bed6-46ed174566dc" />


