### PR TITLE
next/previous/cancel buttons on item registration

### DIFF
--- a/app/views/items/new.html.erb
+++ b/app/views/items/new.html.erb
@@ -2,6 +2,7 @@
   <%= render SdrViewComponents::Elements::HeadingComponent.new(level: :h1, text: t('edit.items.new.title'), classes: 'mb-3') %>
 
   <% form_id = 'tabbed_form' %>
+  <% cancel_path = (request.referer if request.referer.present? && request.referer.exclude?(new_item_path)) || root_path %>
 
   <%= render SdrViewComponents::TabForm::HiddenFieldsFormComponent.new(model: @item_form, id: form_id, url: items_path) %>
 
@@ -14,7 +15,7 @@
     <% form_with(model: @item_form, url: items_path, html: { id: form_id }, builder: SdrViewComponents::TabForm::TabbedFormBuilder) do |form| %>
       <% tab_list.with_pane(SdrViewComponents::TabForm::PaneComponent.new(tab_name: :details,
                                                                           label: t('edit.items.tabs.details.label'),
-                                                                          mark_required: true)) do %>
+                                                                          mark_required: true)) do |pane| %>
         <%= render Edit::SourceIdChoiceComponent.new(form:) %>
 
         <%= render SdrViewComponents::Forms::TextAreaComponent.new(form:, field_name: :title,
@@ -27,46 +28,86 @@
                                                                       options: Constants::REGISTRATION_CONTENT_TYPES,
                                                                       label_text: t('edit.items.fields.content_type.label'),
                                                                       label_mark_required: true,
-                                                                      label_classes: 'fw-bold') %>
+                                                                      label_classes: 'fw-bold',
+                                                                      container_classes: 'mb-3') %>
+        <% pane.with_footer do %>
+          <div class="d-flex">
+            <%= render SdrViewComponents::Elements::ButtonLinkComponent.new(label: 'Cancel', link: cancel_path, variant: :link) %>
+            <%= render SdrViewComponents::Elements::ButtonComponent.new(variant: :primary, classes: 'ms-2',
+                                                                        data: { controller: 'sdr-tab-nav', sdr_tab_nav_tab_id_value: pane.tab_id, action: 'click->sdr-tab-nav#showNext' }) do %>
+              Next <%= right_arrow_icon %>
+            <% end %>
+          </div>
+        <% end %>
       <% end %>
 
       <% tab_list.with_pane(SdrViewComponents::TabForm::PaneComponent.new(tab_name: :rights,
                                                                           label: t('edit.items.tabs.rights.label'),
-                                                                          mark_required: true)) do %>
+                                                                          mark_required: true)) do |pane| %>
         <%= render SdrViewComponents::Forms::SelectFieldComponent.new(form:, field_name: :admin_policy_druid,
                                                                       options: @apo_options,
                                                                       label_text: t('edit.items.fields.admin_policy_druid.label'),
                                                                       label_mark_required: true,
                                                                       label_classes: 'fw-bold') %>
+
+        <% pane.with_footer do %>
+          <div class="d-flex">
+            <%= render SdrViewComponents::Elements::ButtonLinkComponent.new(label: 'Cancel', link: cancel_path, variant: :link) %>
+            <%= render SdrViewComponents::Elements::ButtonComponent.new(label: 'Previous', variant: :'outline-primary', classes: 'ms-2',
+                                                                        data: { controller: 'sdr-tab-nav', sdr_tab_nav_tab_id_value: pane.tab_id, action: 'click->sdr-tab-nav#showPrevious' }) %>
+            <%= render SdrViewComponents::Elements::ButtonComponent.new(variant: :primary, classes: 'ms-2',
+                                                                        data: { controller: 'sdr-tab-nav', sdr_tab_nav_tab_id_value: pane.tab_id, action: 'click->sdr-tab-nav#showNext' }) do %>
+              Next <%= right_arrow_icon %>
+            <% end %>
+          </div>
+        <% end %>
       <% end %>
 
       <% tab_list.with_pane(SdrViewComponents::TabForm::PaneComponent.new(tab_name: :release,
                                                                           label: t('edit.items.tabs.release.pane'),
-                                                                          help_text: t('edit.items.tabs.release.help_text'))) do %>
+                                                                          help_text: t('edit.items.tabs.release.help_text'))) do |pane| %>
         <%= render SdrViewComponents::Forms::HasOneComponent.new(form:,
                                                                  field_name: :release_tags,
                                                                  form_component: Edit::ReleaseTagsComponent,
                                                                  fieldset_label: t('edit.items.tabs.release.pane')) %>
+
+        <% pane.with_footer do %>
+          <div class="d-flex">
+            <%= render SdrViewComponents::Elements::ButtonLinkComponent.new(label: 'Cancel', link: cancel_path, variant: :link) %>
+            <%= render SdrViewComponents::Elements::ButtonComponent.new(label: 'Previous', variant: :'outline-primary', classes: 'ms-2',
+                                                                        data: { controller: 'sdr-tab-nav', sdr_tab_nav_tab_id_value: pane.tab_id, action: 'click->sdr-tab-nav#showPrevious' }) %>
+            <%= render SdrViewComponents::Elements::ButtonComponent.new(variant: :primary, classes: 'ms-2',
+                                                                        data: { controller: 'sdr-tab-nav', sdr_tab_nav_tab_id_value: pane.tab_id, action: 'click->sdr-tab-nav#showNext' }) do %>
+              Next <%= right_arrow_icon %>
+            <% end %>
+          </div>
+        <% end %>
       <% end %>
 
       <% tab_list.with_pane(SdrViewComponents::TabForm::PaneComponent.new(tab_name: :deposit,
                                                                           label: t('edit.items.tabs.deposit.label'),
                                                                           help_text: t('edit.items.tabs.deposit.help_text'),
-                                                                          mark_required: true)) do %>
-        <div class="d-flex justify-content-end">
-          <%= render SdrViewComponents::Forms::SubmitComponent.new(
-                label: t('edit.items.new.buttons.register_add_files'),
-                form_id: form.id,
-                value: ItemsController::DRAFT_TO_ADD_FILES_VALUE,
-                classes: 'me-2'
-              ) %>
-          <%= render SdrViewComponents::Forms::SubmitComponent.new(
-                label: t('edit.items.new.buttons.register'),
-                form_id: form.id,
-                value: ItemsController::DRAFT_VALUE,
-                variant: 'outline-primary'
-              ) %>
-        </div>
+                                                                          mark_required: true)) do |pane| %>
+        <% pane.with_footer do %>
+          <div class="d-flex">
+            <%= render SdrViewComponents::Elements::ButtonLinkComponent.new(label: 'Cancel', link: cancel_path, variant: :link) %>
+            <%= render SdrViewComponents::Elements::ButtonComponent.new(label: 'Previous', variant: :'outline-primary', classes: 'ms-2',
+                                                                        data: { controller: 'sdr-tab-nav', sdr_tab_nav_tab_id_value: pane.tab_id, action: 'click->sdr-tab-nav#showPrevious' }) %>
+            <%= render SdrViewComponents::Forms::SubmitComponent.new(
+                  label: t('edit.items.new.buttons.register_add_files'),
+                  form_id: form.id,
+                  value: ItemsController::DRAFT_TO_ADD_FILES_VALUE,
+                  classes: 'ms-2'
+                ) %>
+            <%= render SdrViewComponents::Forms::SubmitComponent.new(
+                  label: t('edit.items.new.buttons.register'),
+                  form_id: form.id,
+                  value: ItemsController::DRAFT_VALUE,
+                  variant: 'outline-primary',
+                  classes: 'ms-2'
+                ) %>
+          </div>
+        <% end %>
       <% end %>
     <% end %>
   <% end %>

--- a/config/importmap.rb
+++ b/config/importmap.rb
@@ -7,7 +7,8 @@ pin '@hotwired/turbo-rails', to: 'turbo.min.js'
 pin '@hotwired/stimulus', to: 'stimulus.min.js'
 pin '@hotwired/stimulus-loading', to: 'stimulus-loading.js'
 pin_all_from 'app/javascript/controllers', under: 'controllers'
-pin 'bootstrap', to: 'bootstrap.bundle.min.js'
+pin '@popperjs/core', to: 'https://cdn.jsdelivr.net/npm/@popperjs/core@2.11.8'
+pin 'bootstrap', to: 'https://cdn.jsdelivr.net/npm/bootstrap@5.3.3/+esm'
 pin 'stimulus-autocomplete' # @3.1.0
 pin '@andypf/json-viewer', to: '@andypf--json-viewer.js' # @2.4.0
 pin 'sdr_view_components/toast_controller', to: 'sdr_view_components/toast_controller.js'

--- a/spec/system/create_item_spec.rb
+++ b/spec/system/create_item_spec.rb
@@ -48,18 +48,28 @@ RSpec.describe 'Create an item' do
     it 'registers a valid cocina object' do
       visit new_item_path
 
+      expect(page).to have_link('Cancel', href: root_path)
+      expect(page).to have_button('Next')
+      expect(page).to have_no_button('Previous')
+
       fill_in 'Source ID', with: 'new:source-id'
       fill_in 'Title', with: 'The Title'
       select 'image', from: 'Content type'
 
-      find_by_id('rights-tab').click
+      click_button 'Next'
+      expect(page).to have_css('#rights-tab.active')
       select apo_title, from: 'APO'
 
-      find_by_id('release-tab').click
+      click_button 'Next'
+      expect(page).to have_css('#release-tab.active')
       choose 'Release to:'
       check 'SearchWorks'
 
-      find_by_id('deposit-tab').click
+      click_button 'Next'
+      expect(page).to have_css('#deposit-tab.active')
+      expect(page).to have_button('Previous')
+      expect(page).to have_no_button('Next')
+
       click_button('Register only')
 
       expect(page).to have_current_path("/objects/#{druid}")
@@ -129,6 +139,22 @@ RSpec.describe 'Create an item' do
         expect(request_cocina_object.type).to eq(Cocina::Models::ObjectType.book)
       end
       expect(Sdr::Repository).not_to have_received(:accession)
+    end
+
+    it 'cancels item creation' do
+      visit new_item_path
+
+      click_link 'Cancel'
+      expect(page).to have_current_path(root_path)
+    end
+
+    it 'cancels item creation returning to referring page' do
+      visit root_path
+      click_link_or_button 'Item'
+
+      expect(page).to have_link('Cancel')
+      click_link 'Cancel'
+      expect(page).to have_current_path(root_path)
     end
   end
 


### PR DESCRIPTION
Fixes #284 - Mimics H3 layout.  Cancel button returns to referrer or home page.

<img width="1229" height="545" alt="Screenshot 2026-08-28 at 4 58 06 PM" src="https://github.com/user-attachments/assets/024406ee-aa2b-4dea-b877-a8cddb9f7f1e" />


<img width="556" height="329" alt="Screenshot 2026-08-28 at 4 48 22 PM" src="https://github.com/user-attachments/assets/d603a90b-cdff-4a7b-ae0f-83e1fb28aeb3" />
<img width="646" height="374" alt="Screenshot 2026-08-28 at 4 48 28 PM" src="https://github.com/user-attachments/assets/e2eccfaf-eee2-4455-804d-fa7a9b5258a0" />
